### PR TITLE
547289 - Provide javadoc for org.eclipse.passage.lic.api package

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/ConditionTransport.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/ConditionTransport.java
@@ -17,7 +17,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
- * Transport interface for {@link LicensingCondition}(s)
+ * Transport interface for {@link LicensingCondition}(s).
+ *
+ * @since 0.4.0
  */
 public interface ConditionTransport {
 

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/ConditionTransportRegistry.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/ConditionTransportRegistry.java
@@ -23,7 +23,7 @@ import java.util.Map;
  *
  * @see ConditionTransport
  * @see LicensingCondition
- * @see #getConditionTransportForContentType(String) 
+ * @see #getConditionTransportForContentType(String)
  * @since 0.4.0
  */
 public interface ConditionTransportRegistry {
@@ -48,7 +48,7 @@ public interface ConditionTransportRegistry {
 	ConditionTransport getConditionTransportForContentType(String contentType);
 
     /**
-     * Appends the {@code transport} to the <i>registry</i> with the given set of properties.
+     * Adds the {@code transport} to the <i>registry</i> with the given set of properties.
      *
      * @param transport  a transport to be registered
      * @param properties the transport properties, like {@link ConditionMiner}s

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/ConditionTransportRegistry.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/ConditionTransportRegistry.java
@@ -18,11 +18,12 @@ import java.util.Map;
  * Contract for a registry of {@link ConditionTransport}s.
  *
  * <p>As {@link LicensingCondition} can be persisted in any form, a {@link ConditionTransport}
- * is associated with a particular  <i>content type</i> (like <i>application/json</i> or <i>application/xmk</i>).
+ * is associated with a particular  <i>content type</i>.
  * </p>
  *
  * @see ConditionTransport
  * @see LicensingCondition
+ * @see #getConditionTransportForContentType(String) 
  * @since 0.4.0
  */
 public interface ConditionTransportRegistry {
@@ -40,7 +41,7 @@ public interface ConditionTransportRegistry {
      * {@link LicensingCondition}s in the given {@code contentType}. The value is nullable.
      * </p>
      *
-     * @param contentType string representation of
+     * @param contentType string representation of content type (like <i>application/json</i> or <i>application/xmk</i>)
      * @return a {@link ConditionTransport} registered for the given {@code contentType}, if any, and {@code null} otherwise.
      * @see #registerConditionTransport(ConditionTransport, Map)
      */

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/ConditionTransportRegistry.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/ConditionTransportRegistry.java
@@ -23,6 +23,8 @@ import java.util.Map;
  *
  * @see ConditionTransport
  * @see LicensingCondition
+ *
+ * @since 0.4.0
  * */
 public interface ConditionTransportRegistry {
 

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/ConditionTransportRegistry.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/ConditionTransportRegistry.java
@@ -14,14 +14,44 @@ package org.eclipse.passage.lic.api.conditions;
 
 import java.util.Map;
 
+/**
+ * Contract for a registry of {@link ConditionTransport}s.
+ *
+ * <p>As {@link LicensingCondition} can be persisted in any form, a {@link ConditionTransport}
+ * is associated with a particular  <i>content type</i> (like <i>application/json</i> or <i>application/xmk</i>).
+ * </p>
+ *
+ * @see ConditionTransport
+ * @see LicensingCondition
+ * */
 public interface ConditionTransportRegistry {
 
+	/**
+	 * Returns an aggregate of all registered {@link ConditionTransport}s.
+	 *
+	 * @return all registered {@link ConditionTransport}s.
+	 * */
 	Iterable<ConditionTransport> getConditionTransports();
 
+	/**
+	 * <p>
+	 * Returns {@link ConditionTransport}, which is registered to handle (read and write)
+	 * {@link LicensingCondition}s in the given {@code contentType}. The value is nullable.
+	 * </p>
+	 *
+	 * @return a {@link ConditionTransport} registered for the given {@code contentType}, if any, and {@code null} otherwise.
+	 * @see #registerConditionTransport(ConditionTransport, Map)
+	 * */
 	ConditionTransport getConditionTransportForContentType(String contentType);
 
+	/**
+	 * Appends the {@code transport} to the <i>registry</i> with the given set of properties (like content type).
+	 * */
 	void registerConditionTransport(ConditionTransport transport, Map<String, Object> properties);
 
+	/**
+	 * Removes the {@code transport} from the <i>registry</i>.
+	 * */
 	void unregisterConditionTransport(ConditionTransport transport, Map<String, Object> properties);
 
 }

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/ConditionTransportRegistry.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/ConditionTransportRegistry.java
@@ -23,37 +23,43 @@ import java.util.Map;
  *
  * @see ConditionTransport
  * @see LicensingCondition
- *
  * @since 0.4.0
- * */
+ */
 public interface ConditionTransportRegistry {
 
-	/**
-	 * Returns an aggregate of all registered {@link ConditionTransport}s.
-	 *
-	 * @return all registered {@link ConditionTransport}s.
-	 * */
+    /**
+     * Returns an aggregate of all registered {@link ConditionTransport}s.
+     *
+     * @return all registered {@link ConditionTransport}s.
+     */
 	Iterable<ConditionTransport> getConditionTransports();
 
-	/**
-	 * <p>
-	 * Returns {@link ConditionTransport}, which is registered to handle (read and write)
-	 * {@link LicensingCondition}s in the given {@code contentType}. The value is nullable.
-	 * </p>
-	 *
-	 * @return a {@link ConditionTransport} registered for the given {@code contentType}, if any, and {@code null} otherwise.
-	 * @see #registerConditionTransport(ConditionTransport, Map)
-	 * */
+    /**
+     * <p>
+     * Returns {@link ConditionTransport}, which is registered to handle (read and write)
+     * {@link LicensingCondition}s in the given {@code contentType}. The value is nullable.
+     * </p>
+     *
+     * @param contentType string representation of
+     * @return a {@link ConditionTransport} registered for the given {@code contentType}, if any, and {@code null} otherwise.
+     * @see #registerConditionTransport(ConditionTransport, Map)
+     */
 	ConditionTransport getConditionTransportForContentType(String contentType);
 
-	/**
-	 * Appends the {@code transport} to the <i>registry</i> with the given set of properties (like content type).
-	 * */
+    /**
+     * Appends the {@code transport} to the <i>registry</i> with the given set of properties.
+     *
+     * @param transport  a transport to be registered
+     * @param properties the transport properties, like {@link ConditionMiner}s
+     */
 	void registerConditionTransport(ConditionTransport transport, Map<String, Object> properties);
 
-	/**
-	 * Removes the {@code transport} from the <i>registry</i>.
-	 * */
+    /**
+     * Removes the {@code transport} from the <i>registry</i>.
+     *
+     * @param transport  a transport to be unregistered
+     * @param properties the transport properties
+     */
 	void unregisterConditionTransport(ConditionTransport transport, Map<String, Object> properties);
 
 }

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/LicensingCondition.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/LicensingCondition.java
@@ -17,66 +17,64 @@ import java.util.Date;
 import org.eclipse.passage.lic.api.access.PermissionEmitter;
 
 /**
- *
  * Defines the condition to be evaluated by {@link PermissionEmitter} <br/>
  * Obtained from {@link ConditionMiner}
  *
  * @since 0.5.0
- *
  */
 public interface LicensingCondition {
-	/**
-	 * Returns unique identifier of a feature under licensing.
-	 *
-	 * @return feature identifier
-	 */
+    /**
+     * Returns unique identifier of a feature under licensing.
+     *
+     * @return feature identifier
+     */
 	String getFeatureIdentifier();
 
-	/**
+    /**
      * Returns descriptor of the feature version allowed by this licensing condition.
      *
      * @return version descriptor
-     * */
+     */
 	String getMatchVersion();
 
-	/**
+    /**
      * Returns rule of version matching, like "perfect match" or "equal or greater".
      *
      * @return match rule
-     * */
+     */
 	String getMatchRule();
 
-	/**
-	 * Returns the validity period start date of this licensing condition. This is
-	 * the value of its <code>"validFrom"</code> attribute.
-	 *
-	 * @return the valid from
-	 */
+    /**
+     * Returns the validity period start date of this licensing condition. This is
+     * the value of its <code>"validFrom"</code> attribute.
+     *
+     * @return the valid from
+     */
 	Date getValidFrom();
 
-	/**
-	 * Returns the validity period end date of this licensing condition. This is the
-	 * value of its <code>"validUntil"</code> attribute.
-	 *
-	 * @return the valid until
-	 */
+    /**
+     * Returns the validity period end date of this licensing condition. This is the
+     * value of its <code>"validUntil"</code> attribute.
+     *
+     * @return the valid until
+     */
 	Date getValidUntil();
 
-	/**
-	 * The type of condition like "time" or "hardware".
-	 *
-	 * @return condition type
-	 */
+    /**
+     * The type of condition like "time" or "hardware".
+     *
+     * @return condition type
+     */
 	String getConditionType();
 
-	/**
+    /**
      * Returns additional data encoded in a single string value.
-	 * The expression is utilized by {@link PermissionEmitter} in conjunction with {@code conditionType}
+     * The expression is utilized by {@link PermissionEmitter} in conjunction with {@code conditionType}
      *
      * @return enlistment of additional information of this licencing condition
-	 * @see PermissionEmitter
-	 * @see #getConditionType
-     * */
+     * @see PermissionEmitter
+     * @see #getConditionType
+     */
 	String getConditionExpression();
 
 }


### PR DESCRIPTION
- javadoc is added to _ConditionTransportRegistry_
- _since_ versions are deduced and appended to both _ConditionTransport_* classes