### PR TITLE
Bug 552650 - Include Eclipse Passage 0.7.0 M2 for SimRel 2019-12 M2

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/features/org.eclipse.passage.lbc.execute.feature/feature.xml
+++ b/features/org.eclipse.passage.lbc.execute.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.lbc.execute.feature"
       label="%featureName"
-      version="0.6.0.qualifier"
+      version="0.7.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.passage.lbc.target.feature/feature.xml
+++ b/features/org.eclipse.passage.lbc.target.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.lbc.target.feature"
       label="%featureName"
-      version="0.6.0.qualifier"
+      version="0.7.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.passage.ldc.feature/feature.xml
+++ b/features/org.eclipse.passage.ldc.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.ldc.feature"
       label="%featureName"
-      version="0.6.0.qualifier"
+      version="0.7.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.passage.ldc"
       license-feature="org.eclipse.license"

--- a/features/org.eclipse.passage.lic.compile.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.compile.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.lic.compile.feature"
       label="%featureName"
-      version="0.6.0.qualifier"
+      version="0.7.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.passage.lic.define.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.define.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.lic.define.feature"
       label="%featureName"
-      version="0.6.0.qualifier"
+      version="0.7.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.passage.lic.execute.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.execute.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.lic.execute.feature"
       label="%featureName"
-      version="0.6.0.qualifier"
+      version="0.7.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.passage.loc.operator.feature/feature.xml
+++ b/features/org.eclipse.passage.loc.operator.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.loc.operator.feature"
       label="%featureName"
-      version="0.6.0.qualifier"
+      version="0.7.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
@@ -31,13 +31,13 @@
       %license
    </license>
 
-   <requires>
-      <import feature="org.eclipse.passage.lic.define.feature" version="0.0.0" match="equivalent"/>
-   </requires>
-
    <includes
          id="org.eclipse.passage.loc.dashboard.feature"
          version="0.0.0"/>
+
+   <requires>
+      <import feature="org.eclipse.passage.lic.define.feature" version="0.0.0" match="equivalent"/>
+   </requires>
 
    <plugin
          id="org.eclipse.passage.loc.operator"

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>./releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/products/org.eclipse.passage.lbc.server.product/org.eclipse.passage.lbc.server.product
+++ b/products/org.eclipse.passage.lbc.server.product/org.eclipse.passage.lbc.server.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Passage Licensing Data Server" uid="org.eclipse.passage.lbc.server.product" id="org.eclipse.passage.lbc.server.product" application="org.eclipse.passage.lbc.server.application" version="0.6.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Passage Licensing Data Server" uid="org.eclipse.passage.lbc.server.product" id="org.eclipse.passage.lbc.server.product" application="org.eclipse.passage.lbc.server.application" version="0.7.0.qualifier" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>

--- a/products/org.eclipse.passage.lbc.server.product/pom.xml
+++ b/products/org.eclipse.passage.lbc.server.product/pom.xml
@@ -23,7 +23,7 @@ xmlns="http://maven.apache.org/POM/4.0.0"
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/products/org.eclipse.passage.loc.operator.product/org.eclipse.passage.loc.operator.product.product
+++ b/products/org.eclipse.passage.loc.operator.product/org.eclipse.passage.loc.operator.product.product
@@ -13,7 +13,7 @@
 		ArSysOp - initial API and implementation
 -->
 
-<product name="Passage Licensing Operator Workbench" uid="org.eclipse.passage.loc.operator.product" id="org.eclipse.passage.loc.operator.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="0.6.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Passage Licensing Operator Workbench" uid="org.eclipse.passage.loc.operator.product" id="org.eclipse.passage.loc.operator.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="0.7.0.qualifier" useFeatures="true" includeLaunchers="true">
 
    <aboutInfo>
    </aboutInfo>

--- a/products/org.eclipse.passage.loc.operator.product/pom.xml
+++ b/products/org.eclipse.passage.loc.operator.product/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.passage.lbc.aggregator/pom.xml
+++ b/releng/org.eclipse.passage.lbc.aggregator/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 	<modules>

--- a/releng/org.eclipse.passage.lbc.repository/pom.xml
+++ b/releng/org.eclipse.passage.lbc.repository/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 	

--- a/releng/org.eclipse.passage.ldc.aggregator/pom.xml
+++ b/releng/org.eclipse.passage.ldc.aggregator/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 	<modules>

--- a/releng/org.eclipse.passage.ldc.repository/pom.xml
+++ b/releng/org.eclipse.passage.ldc.repository/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 	

--- a/releng/org.eclipse.passage.lic.aggregator/pom.xml
+++ b/releng/org.eclipse.passage.lic.aggregator/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.passage.lic.repository/pom.xml
+++ b/releng/org.eclipse.passage.lic.repository/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.passage.loc.aggregator/pom.xml
+++ b/releng/org.eclipse.passage.loc.aggregator/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.passage.loc.repository/pom.xml
+++ b/releng/org.eclipse.passage.loc.repository/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.passage.parent/pom.xml
+++ b/releng/org.eclipse.passage.parent/pom.xml
@@ -20,7 +20,7 @@
 
 	<groupId>org.eclipse.passage</groupId>
 	<artifactId>org.eclipse.passage.parent</artifactId>
-	<version>0.6.0-SNAPSHOT</version>
+	<version>0.7.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<prerequisites>

--- a/releng/org.eclipse.passage.target/pom.xml
+++ b/releng/org.eclipse.passage.target/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 


### PR DESCRIPTION
Version bump to 0.7.0

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>