### PR TITLE
552748 releng/aggregator projects have incorrect artifactID

### DIFF
--- a/releng/org.eclipse.passage.lbc.aggregator/pom.xml
+++ b/releng/org.eclipse.passage.lbc.aggregator/pom.xml
@@ -17,7 +17,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>org.eclipse.passage.lbc.agregator</artifactId>
+	<artifactId>org.eclipse.passage.lbc.aggregator</artifactId>
 	<packaging>pom</packaging>
 
 	<parent>

--- a/releng/org.eclipse.passage.ldc.aggregator/pom.xml
+++ b/releng/org.eclipse.passage.ldc.aggregator/pom.xml
@@ -17,7 +17,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>org.eclipse.passage.ldc.agregator</artifactId>
+	<artifactId>org.eclipse.passage.ldc.aggregator</artifactId>
 	<packaging>pom</packaging>
 
 	<parent>


### PR DESCRIPTION
 Typo in artifactId is fixed for the following releng projects
 - org.eclipse.passage.lbc.aggregator
 - org.eclipse.passage.ldc.aggregator

Signed-off-by: Elena Parovyshnaia <elena.parovyshnaya@gmail.com>