### PR TITLE
547289 Provide javadoc for org.eclipse.passage.lic.api package

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/LicensingConfiguration.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/LicensingConfiguration.java
@@ -17,6 +17,8 @@ package org.eclipse.passage.lic.api;
  * <p>
  * It represents the pair <code>{id, version</code>} for the running product.
  * </p>
+ *
+ * @since 0.4.0
  */
 public interface LicensingConfiguration {
 

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/LicensingEvents.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/LicensingEvents.java
@@ -13,9 +13,7 @@
 package org.eclipse.passage.lic.api;
 
 /**
- * 
  * @since 0.4.0
- *
  */
 public final class LicensingEvents {
 

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/LicensingException.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/LicensingException.java
@@ -21,7 +21,6 @@ package org.eclipse.passage.lic.api;
  * 
  * @since 0.4.0
  * @see LicensingResult
- *
  */
 public class LicensingException extends Exception {
 

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/requirements/LicensingRequirement.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/requirements/LicensingRequirement.java
@@ -14,15 +14,24 @@ package org.eclipse.passage.lic.api.requirements;
 
 /**
  * The usage constraint defined for specific feature identifier with given
- * version. Obtained from {@link RequirementResolver}
+ * version. It is declared at a program development phase during creation of a feature under licensing.
+ * Accessed at the program runtime by {@link RequirementResolver}s.
  *
+ * @see RequirementResolver
+ * @since 0.4.0
  */
 public interface LicensingRequirement {
 
 	String getFeatureProvider();
-	
+
+	/**
+	 * Name of the feature under requirement
+	 */
 	String getFeatureName();
-	
+
+	/**
+	 * Version of the feature under requirement
+	 */
 	String getFeatureVersion();
 	
 	String getFeatureIdentifier();
@@ -36,6 +45,13 @@ public interface LicensingRequirement {
 	 */
 	String getRestrictionLevel();
 
+	/**
+	 * The original physical source under the program installation,
+	 * where this requirement has been read from by some {@code RequirementResolver}.
+	 *
+	 * @see RequirementResolver
+	 * @return physical source (like file) defined by a program under protection
+	 * */
 	Object getRequirementSource();
 	
 }

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/requirements/RequirementEvents.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/requirements/RequirementEvents.java
@@ -16,6 +16,9 @@ import static org.eclipse.passage.lic.api.LicensingEvents.ALL_SUB_TOPICS;
 import static org.eclipse.passage.lic.api.LicensingEvents.TOPIC_BASE;
 import static org.eclipse.passage.lic.api.LicensingEvents.TOPIC_SEP;
 
+/**
+ * @since 0.4.0
+ */
 public final class RequirementEvents {
 
 	private RequirementEvents() {

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/requirements/RequirementResolver.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/requirements/RequirementResolver.java
@@ -15,18 +15,28 @@ package org.eclipse.passage.lic.api.requirements;
 import org.eclipse.passage.lic.api.LicensingConfiguration;
 
 /**
- * 
- * Resolves the given configuration and produces
- * {@link LicensingRequirement}(s).
+ * <p>General contract for a service capable to obtain (resolve) {@link LicensingRequirement}s
+ * from a particular installation of a program under licensing. </p>
  *
+ * <p>During a program development some features are declared that the ones under licensing.
+ * Such a declarations can be reflected in a type of physical sources under a particular program installation.
+ * Example sources are <i>manifest.mf</i>, <i>OSGI component manifest</i>. </p>
+ *
+ * <p>At the program runtime a {@code RequirementResolver} reads particular type of physical sources and produce
+ * set of {@link LicensingRequirement}s that are defined there.</p>
+ *
+ * @see LicensingRequirement
+ * @since 0.4.0
  */
 public interface RequirementResolver {
 
-	/**
-	 * 
-	 * @param configuration
-	 * @return
-	 */
-	Iterable<LicensingRequirement> resolveLicensingRequirements(LicensingConfiguration configuration);
+    /**
+     * Having access to a particular type of physical sources,
+     * reads them for {@link LicensingRequirement} declared there.
+     *
+     * @param configuration general configuration
+     * @return resolved set of {@link LicensingRequirement}s, not nullable
+     */
+    Iterable<LicensingRequirement> resolveLicensingRequirements(LicensingConfiguration configuration);
 
 }

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/restrictions/RestrictionExecutor.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/restrictions/RestrictionExecutor.java
@@ -16,12 +16,13 @@ import org.eclipse.passage.lic.api.LicensingResult;
 
 /**
  * 
- * Realize the {@link RestrictionVerdict}(s) for the licensed feature:
+ * Implement the {@link RestrictionVerdict}(s) for the licensed feature:
  * <li>early exit from command line tools with notice</li>
  * <li>blocking dialogs for UI application</li>
  * <li>filtering out the UI</li>
  * <li>blocking of bundles using OSGi level</li>
  *
+ * @since 0.4.0
  */
 public interface RestrictionExecutor {
 

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/restrictions/RestrictionExecutorRegistry.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/restrictions/RestrictionExecutorRegistry.java
@@ -12,6 +12,12 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.api.restrictions;
 
+/**
+ * Library of {@link RestrictionExecutor}s registered at a program runtime.
+ *
+ * @see RestrictionExecutor
+ * @since 0.4.0
+ */
 public interface RestrictionExecutorRegistry {
 
 	String getDefaultRestrictionLevelIdentifier();

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/restrictions/RestrictionLevelDescriptor.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/restrictions/RestrictionLevelDescriptor.java
@@ -1,5 +1,8 @@
 package org.eclipse.passage.lic.api.restrictions;
 
+/**
+ * @since 0.4.0
+ */
 public interface RestrictionLevelDescriptor {
 
 	String getIdentifier();

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/restrictions/RestrictionVerdict.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/restrictions/RestrictionVerdict.java
@@ -17,17 +17,32 @@ import org.eclipse.passage.lic.api.access.PermissionExaminer;
 import org.eclipse.passage.lic.api.requirements.LicensingRequirement;
 
 /**
- * 
- * The data required to execute the permission, produced by
+ *
+ * The data required to execute the restriction, produced by
  * {@link PermissionExaminer} and consumed by {@link RestrictionExecutor}
  *
+ * @since 0.4.0
  */
 public interface RestrictionVerdict {
 
+	/**
+	 * General configuration
+	 */
 	LicensingConfiguration getLicensingConfiguration();
 
+	/**
+	 * <p>The original {@code LicensingRequirement} which was admitted by {@code PermissionExaminer}
+	 * to be not satisfied  by existing set of {@code FeaturePermission}s.</p>
+	 *
+	 * @see LicensingRequirement
+	 * @see org.eclipse.passage.lic.api.access.FeaturePermission
+	 * @see org.eclipse.passage.lic.api.access.PermissionExaminer
+	 */
 	LicensingRequirement getLicensingRequirement();
 
+	/**
+	 * Level of restriction severity, described freely, like "warn" or "fatal"
+	 */
 	String getRestrictionLevel();
 
 	int getRestrictionCode();


### PR DESCRIPTION
- documentation for `requiremen` and `restriction` packages
- doc formatting and `since`-tag for central classes

Signed-off-by: Elena Parovyshnaia <elena.parovyshnaya@gmail.com>