### PR TITLE
52 Build Passage on openJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 dist: trusty
 jdk:
-  - oraclejdk8
+  - openjdk8
   
 notifications:
   email:


### PR DESCRIPTION
Instruct TraviceCI to build the product on OpenJdk8 instead of OracleJDK8

Signed-off-by: Elena Parovyshnaia <elena.parovyshnaya@gmail.com>