### PR TITLE
#553435 integration test for permission observation

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/permission/BasePermissionObservatory.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/permission/BasePermissionObservatory.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.permission;
+
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.StreamSupport;
+
+import org.eclipse.passage.lic.api.access.FeaturePermission;
+import org.eclipse.passage.lic.internal.base.permission.observatory.GuardedObservatory;
+
+/**
+ * <p>
+ * Base implementation for {@linkplain PermissionObservatory} component.
+ * </p>
+ * <p>
+ * Covers {@linkplain GuardedObservatory} tuned for permission tracking and is
+ * it's representation for the domain specific environment.
+ * </p>
+ * 
+ * @since 0.6
+ */
+public final class BasePermissionObservatory implements PermissionObservatory {
+	private final GuardedObservatory<LimitedPermission> observatory;
+
+	public BasePermissionObservatory(int seconds, Consumer<Set<LimitedPermission>> farewell) {
+		this.observatory = new GuardedObservatory<LimitedPermission>(seconds, farewell);
+	}
+
+	public void watch(Iterable<FeaturePermission> permissions) {
+		onEachPermission(permissions, limited -> observatory.watch(limited));
+	}
+
+	public void forget(Iterable<FeaturePermission> permissions) {
+		onEachPermission(permissions, limited -> observatory.forget(limited));
+	}
+
+	public void open() {
+		observatory.open();
+	}
+
+	private void onEachPermission(Iterable<FeaturePermission> permissions, Consumer<LimitedPermission> action) {
+		StreamSupport.stream(permissions.spliterator(), false)//
+				.map(LimitedPermission::new) //
+				.forEach(limited -> action.accept(limited));
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/permission/LimitedPermission.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/permission/LimitedPermission.java
@@ -15,8 +15,15 @@ package org.eclipse.passage.lic.internal.base.permission;
 import java.util.Date;
 
 import org.eclipse.passage.lic.api.access.FeaturePermission;
+import org.eclipse.passage.lic.internal.base.permission.observatory.GuardedObservatory;
 import org.eclipse.passage.lic.internal.base.permission.observatory.Limited;
 
+/**
+ * Adapter for {@linkplain FeaturePermission} to implement {@linkplain Limited}
+ * interface to be properly tracked by {@linkplain GuardedObservatory}
+ * 
+ * @since 0.6
+ */
 public final class LimitedPermission implements Limited {
 	private final FeaturePermission permission;
 
@@ -30,4 +37,13 @@ public final class LimitedPermission implements Limited {
 		return now.before(permission.getLeaseDate()) || now.after(permission.getExpireDate());
 	}
 
+	@Override
+	public int hashCode() {
+		return permission.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return permission.equals(object);
+	}
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/permission/PermissionObservatory.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/permission/PermissionObservatory.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.permission;
+
+import org.eclipse.passage.lic.internal.base.permission.observatory.GuardedObservatory;
+
+/**
+ * Marker interface for a component that holds {@linkplain GuardedObservatory}
+ * for permission tracking.
+ * 
+ * @since 0.6
+ */
+public interface PermissionObservatory {
+
+}

--- a/bundles/org.eclipse.passage.lic.equinox/OSGI-INF/org.eclipse.passage.lic.internal.equinox.access.EquinoxPermissionObservatory.xml
+++ b/bundles/org.eclipse.passage.lic.equinox/OSGI-INF/org.eclipse.passage.lic.internal.equinox.access.EquinoxPermissionObservatory.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" name="org.eclipse.passage.lic.internal.equinox.access.EquinoxPermissionObservatory">
+   <property name="event.topics" value="org/eclipse/passage/lic/api/AccessEvents/conditionsEvaluated"/>
+   <property name="observatory.schedule" type="Integer" value="600"/>
+   <service>
+      <provide interface="org.osgi.service.event.EventHandler"/>
+      <provide interface="org.eclipse.passage.lic.internal.base.permission.PermissionObservatory"/>
+   </service>
+   <reference bind="bindLicensingReporter" interface="org.eclipse.passage.lic.api.LicensingReporter" name="LicensingReporter" unbind="unbindLicensingReporter"/>
+   <implementation class="org.eclipse.passage.lic.internal.equinox.access.EquinoxPermissionObservatory"/>
+</scr:component>

--- a/bundles/org.eclipse.passage.lic.equinox/OSGI-INF/org.eclipse.passage.lic.internal.equinox.access.PermissionObservatory.xml
+++ b/bundles/org.eclipse.passage.lic.equinox/OSGI-INF/org.eclipse.passage.lic.internal.equinox.access.PermissionObservatory.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" name="org.eclipse.passage.lic.internal.equinox.access.PermissionObservatory">
-   <property name="event.topics" value="org/eclipse/passage/lic/api/AccessEvents/conditionsEvaluated"/>
-   <service>
-      <provide interface="org.osgi.service.event.EventHandler"/>
-   </service>
-   <reference bind="bindLicensingReporter" interface="org.eclipse.passage.lic.api.LicensingReporter" name="LicensingReporter" unbind="unbindLicensingReporter"/>
-   <implementation class="org.eclipse.passage.lic.internal.equinox.access.PermissionObservatory"/>
-</scr:component>

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/EquinoxPermissionObservatory.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/EquinoxPermissionObservatory.java
@@ -14,15 +14,16 @@ package org.eclipse.passage.lic.internal.equinox.access;
 
 import static org.eclipse.passage.lic.base.LicensingResults.createEvent;
 
-import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.passage.lic.api.LicensingReporter;
 import org.eclipse.passage.lic.api.access.AccessEvents;
 import org.eclipse.passage.lic.api.access.FeaturePermission;
 import org.eclipse.passage.lic.base.SystemReporter;
+import org.eclipse.passage.lic.internal.base.permission.BasePermissionObservatory;
 import org.eclipse.passage.lic.internal.base.permission.LimitedPermission;
-import org.eclipse.passage.lic.internal.base.permission.observatory.GuardedObservatory;
+import org.eclipse.passage.lic.internal.base.permission.PermissionObservatory;
 import org.eclipse.passage.lic.internal.equinox.EquinoxEvents;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -31,41 +32,44 @@ import org.osgi.service.event.Event;
 import org.osgi.service.event.EventConstants;
 import org.osgi.service.event.EventHandler;
 
+/**
+ * OSGi-driven implementation of {@linkplain PermissionObservatory}.
+ * 
+ * @since 0.6
+ */
 @SuppressWarnings("restriction")
 //FIXME: also listen event "feature-is-not-used-anymore" fired by the product under licensing-> call 'observatory.forget(feature)` 
 //FIXME #553424 - Program under licensing should be able to cause leased FeaturePermission destruction
-@Component(property = EventConstants.EVENT_TOPIC + "=" + AccessEvents.CONDITIONS_EVALUATED)
-public class PermissionObservatory implements EventHandler {
+@Component(property = { EventConstants.EVENT_TOPIC + "=" + AccessEvents.CONDITIONS_EVALUATED,
+		"observatory.schedule:Integer=600" })
+public final class EquinoxPermissionObservatory implements EventHandler, PermissionObservatory {
 
-	private final GuardedObservatory<LimitedPermission> observatory;
+	private BasePermissionObservatory observatory;
 	private LicensingReporter eventBus = SystemReporter.INSTANCE;
 
-	public PermissionObservatory() {
-		this.observatory = new GuardedObservatory<LimitedPermission>(10 * 60, this::fireExpiration);
-	}
-
 	@Activate
-	void activate() {
+	public void activate(Map<String, Object> config) {
+		int schedule = (Integer) config.get("observatory.schedule"); //$NON-NLS-1$
+		observatory = new BasePermissionObservatory(schedule, this::fireExpiration);
 		observatory.open();
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public void handleEvent(Event event) {
-		List<FeaturePermission> payload = (List<FeaturePermission>) event.getProperty(EquinoxEvents.PROPERTY_DATA);
-		payload.stream() //
-				.map(LimitedPermission::new) //
-				.forEach(limited -> observatory.watch(limited));
+		Iterable<FeaturePermission> payload = (Iterable<FeaturePermission>) event
+				.getProperty(EquinoxEvents.PROPERTY_DATA);
+		observatory.watch(payload);
 	}
 
 	@Reference
 	public void bindLicensingReporter(LicensingReporter reporter) {
-		this.eventBus = reporter;
+		eventBus = reporter;
 	}
 
 	public void unbindLicensingReporter(LicensingReporter reporter) {
-		if (this.eventBus == reporter) {
-			this.eventBus = SystemReporter.INSTANCE;
+		if (eventBus == reporter) {
+			eventBus = SystemReporter.INSTANCE;
 		}
 	}
 


### PR DESCRIPTION
observation api improvement: 
 - PermissionObservatory became a marker interface
 - with two implementations: Base and Equinox (not inherited one from another)
 - Base implementation just configures and covers Guarded observatory for the domain
 - Equinox implementation adds event handling

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>