### PR TITLE
#553435 integration test for permission observation

### DIFF
--- a/tests/org.eclipse.passage.lic.integration.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.integration.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.integration.tests
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.integration.tests
-Bundle-Version: 0.5.0.qualifier
+Bundle-Version: 0.6.0.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0",

--- a/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/ConditionType.java
+++ b/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/ConditionType.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.integration.tests.permissionobservatory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.passage.lic.base.LicensingProperties;
+
+/**
+ * Bundle activation properties for {@code EquinoxPermissionObservatory}
+ * 
+ * @since 0.6
+ */
+class ConditionType {
+	private final String type;
+
+	ConditionType(String type) {
+		this.type = type;
+	}
+
+	Map<String, Object> map() {
+		Map<String, Object> output = new HashMap<>();
+		output.put(LicensingProperties.LICENSING_CONDITION_TYPE_ID, type);
+		return output;
+	}
+}

--- a/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/FakeAccessManagerCall.java
+++ b/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/FakeAccessManagerCall.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.integration.tests.permissionobservatory;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.eclipse.passage.lic.api.access.AccessManager;
+import org.eclipse.passage.lic.api.conditions.LicensingCondition;
+import org.eclipse.passage.lic.internal.base.permission.PermissionObservatory;
+import org.eclipse.passage.lic.internal.equinox.access.EquinoxAccessManager;
+import org.eclipse.passage.lic.internal.equinox.access.EquinoxPermissionObservatory;
+import org.osgi.service.event.Event;
+
+/**
+ * <p>
+ * Main testing unit.
+ * </p>
+ * 
+ * <ul>
+ * Here we
+ * <li>fake the service responsible for a condition evaluation with our own
+ * {@linkplain FakePermissionEmitter} - the instance is implanted into actual
+ * {@linkplain AccessManager} service available in OSGi container. This emitter
+ * leases 2-second-TTL permission for each condition.</li>
+ * <li>use our own {@code event bus} instead of {@code Event Admin} of OSGi to
+ * post and handle events</li>
+ * <li>emulate {@linkplain LicensingCondition} with our own implementation to be
+ * source for
+ * {@linkplain AccessManager#evaluateConditions(org.eclipse.passage.lic.api.LicensingConfiguration, Iterable)}
+ * </li>
+ * <li>reconfigure {@linkplain PermissionObservatory} to a schedule proper for
+ * test environments (seconds instead of minutes for production)</li>
+ * <li>finally, call actual {@linkplain AccessManager#evaluateConditions}</li>
+ * <ul>
+ * <p/>
+ * <ul>
+ * We expect, that
+ * <li>during the call {@linkplain AccessManager} posts
+ * {@code condition_evaluated} event to the bus</li>
+ * <li>our event bus resends it to {@linkplain EquinoxPermissionObservatory}
+ * component's event handling function</li>
+ * <li>the leased permission is kept under the observatory's eyes and is
+ * regularly checked on expiration</li>
+ * <li>after the permission TTL is over, the observatory fires
+ * {@code permission_expired} event, which is tracked by our event bus</li>
+ * </ul>
+ * <p>
+ * As event bus is encapsulated here, we also can say, if set of {@code leased
+ * permissions} is precisely equal to the set of {@code expired permissions}.
+ * </p>
+ * 
+ * @since 0.6
+ */
+@SuppressWarnings("restriction")
+class FakeAccessManagerCall {
+	private final EquinoxAccessManager accessManager;
+	private final EquinoxPermissionObservatory observatory;
+	private final LongMemoryEventAdmin eventBus;
+
+	FakeAccessManagerCall(AccessManager accessManager, PermissionObservatory observatory) {
+		this.accessManager = (EquinoxAccessManager) accessManager;
+		this.observatory = (EquinoxPermissionObservatory) observatory;
+		eventBus = new LongMemoryEventAdmin(this::handleLeasing);
+	}
+
+	void reinstall() {
+		accessManager.bindLicensingReporter(eventBus);
+		observatory.bindLicensingReporter(eventBus);
+		accessManager.bindPermissionEmitter( //
+				new FakePermissionEmitter(), //
+				new ConditionType("time").map()); //$NON-NLS-1$
+		observatory.activate(new GuardSchedule(1).map());
+	}
+
+	void leasePermissions(int amount) {
+		accessManager.evaluateConditions(new FakeConfiguration(), conditions(amount));
+	}
+
+	private Iterable<LicensingCondition> conditions(int amount) {
+		return IntStream.range(0, amount) //
+				.mapToObj(i -> new FakeCondition()) //
+				.collect(Collectors.toList());
+	}
+
+	private void handleLeasing(Event leaseEvent) {
+		observatory.handleEvent(leaseEvent);
+	}
+
+	boolean complete() {
+		return eventBus.even();
+	}
+}

--- a/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/FakeCondition.java
+++ b/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/FakeCondition.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.integration.tests.permissionobservatory;
+
+import java.util.Date;
+
+import org.eclipse.passage.lic.api.access.AccessManager;
+import org.eclipse.passage.lic.api.conditions.LicensingCondition;
+
+/**
+ * <p>
+ * As we test only {@linkplain AccessManager#evaluateConditions()} method, we
+ * need to feed it.
+ * </p>
+ * 
+ * <p>
+ * These are dummy conditions, which are valid for 10 minutes since creation
+ * time.
+ * </p>
+ * 
+ * @since 0.6
+ */
+class FakeCondition implements LicensingCondition {
+	private final Date now = new Date();
+
+	@Override
+	public String getFeatureIdentifier() {
+		return "feature"; //$NON-NLS-1$
+	}
+
+	@Override
+	public String getMatchVersion() {
+		return "1.0.0"; //$NON-NLS-1$
+	}
+
+	@Override
+	public String getMatchRule() {
+		return "equal"; //$NON-NLS-1$
+	}
+
+	/**
+	 * Fake condition is valid from creation moment
+	 */
+	@Override
+	public Date getValidFrom() {
+		return now;
+	}
+
+	/**
+	 * Fake condition is valid for 10 minutes from creation
+	 */
+	@Override
+	public Date getValidUntil() {
+		return new Date(now.getTime() + 10 * 60 * 1000);
+	}
+
+	@Override
+	public String getConditionType() {
+		return "time";//$NON-NLS-1$
+	}
+
+	@Override
+	public String getConditionExpression() {
+		return ""; //$NON-NLS-1$
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/FakeConfiguration.java
+++ b/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/FakeConfiguration.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.integration.tests.permissionobservatory;
+
+/**
+ * Dummy licensing configuration
+ * 
+ * @since 0.6
+ */
+class FakeConfiguration implements org.eclipse.passage.lic.api.LicensingConfiguration {
+
+	@Override
+	public String getProductIdentifier() {
+		return "product";//$NON-NLS-1$
+	}
+
+	@Override
+	public String getProductVersion() {
+		return "1.0.0"; //$NON-NLS-1$
+	}
+}

--- a/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/FakePermission.java
+++ b/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/FakePermission.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.integration.tests.permissionobservatory;
+
+import java.util.Date;
+
+import org.eclipse.passage.lic.api.LicensingConfiguration;
+import org.eclipse.passage.lic.api.access.FeaturePermission;
+import org.eclipse.passage.lic.api.conditions.LicensingCondition;
+
+/**
+ * <p>
+ * {@linkplain FakePermissionEmitter} service leases these short-TTL
+ * permissions, configured for several seconds to frm irth to expiration.
+ * </p>
+ * 
+ * @since 0.6
+ */
+class FakePermission implements FeaturePermission {
+	private final LicensingConfiguration configuration;
+	private final LicensingCondition condition;
+	private final int ttl;
+	private final Date now = new Date();
+
+	FakePermission(LicensingConfiguration licensingConfiguration, LicensingCondition condition, int ttl) {
+		this.configuration = licensingConfiguration;
+		this.condition = condition;
+		this.ttl = ttl;
+	}
+
+	@Override
+	public LicensingConfiguration getLicensingConfiguration() {
+		return configuration;
+	}
+
+	@Override
+	public LicensingCondition getLicensingCondition() {
+		return condition;
+	}
+
+	@Override
+	public Date getLeaseDate() {
+		return now;
+	}
+
+	@Override
+	public Date getExpireDate() {
+		return new Date(now.getTime() + ttl * 1000); // permission is valid for TTL seconds
+	}
+}

--- a/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/FakePermissionEmitter.java
+++ b/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/FakePermissionEmitter.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.integration.tests.permissionobservatory;
+
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.eclipse.passage.lic.api.LicensingConfiguration;
+import org.eclipse.passage.lic.api.LicensingException;
+import org.eclipse.passage.lic.api.access.FeaturePermission;
+import org.eclipse.passage.lic.api.access.PermissionEmitter;
+import org.eclipse.passage.lic.api.conditions.LicensingCondition;
+
+/**
+ * Without any questions and regrets we lease a 2-seconds-TTL
+ * {@linkplain FakePermission} for each incoming {@linkplain LicensingCondition}
+ * 
+ * @since 0.6
+ */
+class FakePermissionEmitter implements PermissionEmitter {
+
+	@Override
+	public Iterable<FeaturePermission> emitPermissions(LicensingConfiguration configuration,
+			Iterable<LicensingCondition> conditions) throws LicensingException {
+		return StreamSupport.stream(conditions.spliterator(), false) //
+				.map(c -> new FakePermission(configuration, c, 2)) // 2 seconds TTL
+				.collect(Collectors.toList());
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/GuardSchedule.java
+++ b/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/GuardSchedule.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.integration.tests.permissionobservatory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * <p>
+ * Observatory component is configured to production environment and checks
+ * watched permissions ones in several minutes.
+ * </p>
+ * <p>
+ * For test purposes we must shorten this schedule to seconds for the test to
+ * finish shortly.
+ * </p>
+ * 
+ * @since 0.6
+ */
+class GuardSchedule {
+	private final int seconds;
+
+	GuardSchedule(int seconds) {
+		this.seconds = seconds;
+	}
+
+	Map<String, Object> map() {
+		Map<String, Object> config = new HashMap<>();
+		config.put("observatory.schedule", seconds); //$NON-NLS-1$
+		return config;
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/LongMemoryEventAdmin.java
+++ b/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/LongMemoryEventAdmin.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.integration.tests.permissionobservatory;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.eclipse.passage.lic.api.LicensingReporter;
+import org.eclipse.passage.lic.api.LicensingResult;
+import org.eclipse.passage.lic.api.access.AccessEvents;
+import org.eclipse.passage.lic.internal.base.permission.LimitedPermission;
+import org.eclipse.passage.lic.internal.equinox.EquinoxEvents;
+import org.osgi.service.event.Event;
+
+/**
+ * <p>
+ * As <i>OSGi EventAdmin</i> is not functional (do not process event queue
+ * before the main thread ends) here we emulate it's behavior through the memory
+ * structures.
+ * </p>
+ * 
+ * <p>
+ * Mostly this bus keeps all incoming {@code post} requests in memory.
+ * </p>
+ * <p>
+ * And for the purpose of the test we only must implement
+ * {@link AccessEvents.CONDITIONS_EVALUATED} {@code post}s delivery to a hander.
+ * We do this by means of preconfigured {@code onLease} handler.
+ * </p>
+ * 
+ * @since 0.6
+ */
+@SuppressWarnings("restriction")
+class LongMemoryEventAdmin implements LicensingReporter {
+
+	private final Set<LimitedPermission> leased = new HashSet<>();
+	private final Set<LimitedPermission> expired = new HashSet<>();
+	private final Consumer<Event> onLease;
+
+	LongMemoryEventAdmin(Consumer<Event> onLease) {
+		this.onLease = onLease;
+	}
+
+	@Override
+	public void postResult(LicensingResult result) {
+		Event event = EquinoxEvents.extractEvent(result);
+		String topic = event.getTopic();
+		@SuppressWarnings("unchecked")
+		Iterable<LimitedPermission> data = (Iterable<LimitedPermission>) event.getProperty(EquinoxEvents.PROPERTY_DATA);
+		collectLeased(topic, data);
+		collectExpired(topic, data);
+		if (lease(event.getTopic())) {
+			onLease.accept(event);
+		}
+	}
+
+	@Override
+	public void sendResult(LicensingResult result) {
+		// do nothing: not needed for the test
+	}
+
+	@Override
+	public void logResult(LicensingResult result) {
+		// do nothing: not needed for the test
+	}
+
+	private void collectLeased(String topic, Iterable<LimitedPermission> data) {
+		if (!lease(topic)) {
+			return;
+		}
+		leased.addAll(set(data));
+	}
+
+	private void collectExpired(String topic, Iterable<LimitedPermission> data) {
+		if (!AccessEvents.PERMISSIONS_EXPIRED.equals(topic)) {
+			return;
+		}
+		expired.addAll(set(data));
+	}
+
+	private Set<LimitedPermission> set(Iterable<LimitedPermission> what) {
+		return StreamSupport.stream(what.spliterator(), false).collect(Collectors.toSet());
+	}
+
+	private boolean lease(String topic) {
+		return AccessEvents.CONDITIONS_EVALUATED.equals(topic);
+	}
+
+	boolean even() {
+		return leased.equals(expired);
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/PermissionObservatoryIntegrationTest.java
+++ b/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/permissionobservatory/PermissionObservatoryIntegrationTest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.integration.tests.permissionobservatory;
+
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.passage.lic.api.access.AccessManager;
+import org.eclipse.passage.lic.api.access.FeaturePermission;
+import org.eclipse.passage.lic.internal.base.permission.PermissionObservatory;
+import org.eclipse.passage.lic.internal.equinox.access.EquinoxPermissionObservatory;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+
+/**
+ * 
+ * <p>
+ * Test {@linkplain EquinoxPermissionObservatory} functioning.
+ * </p>
+ * 
+ * <p>
+ * It's a long-running test. With starting up and warming it takes ~25 seconds
+ * on a developer's machine.
+ * </p>
+ * 
+ * @since 0.6
+ */
+@SuppressWarnings("restriction")
+public class PermissionObservatoryIntegrationTest {
+
+	private FakeAccessManagerCall fake;
+
+	@Before
+	public void startup() {
+		Bundle bundle = FrameworkUtil.getBundle(PermissionObservatoryIntegrationTest.class);
+		BundleContext context = bundle.getBundleContext();
+		ServiceReference<AccessManager> accessManager = context.getServiceReference(AccessManager.class);
+		ServiceReference<PermissionObservatory> observatory = context.getServiceReference(PermissionObservatory.class);
+		fake = new FakeAccessManagerCall(context.getService(accessManager), context.getService(observatory));
+		fake.reinstall();
+	}
+
+	/**
+	 * <p>
+	 * The test checks if a {@code condition_evaluated} event (meaning that a
+	 * {@linkplain FeaturePermission} is leased) is properly handled by
+	 * {@linkplain EquinoxPermissionObservatory}.
+	 * </p>
+	 * 
+	 * <p>
+	 * By means of custom event bus ({@linkplain LongMemoryEventAdmin}) at the end
+	 * of the day we can say exactly whether each and every leased permission is
+	 * properly expired or not.
+	 * </p>
+	 * 
+	 * @since 0.6
+	 */
+	@Test
+	public void testObservatoryTracksExpiration() {
+		fake.leasePermissions(4);
+		assertAllAreExpired(2000); // permissions are leased with 2 seconds TTL
+		assertTrue("Some expired permissions are still active", fake.complete()); //$NON-NLS-1$
+	}
+
+	private void assertAllAreExpired(int delay) {
+		waitABit(delay);
+		for (int i = 0; i < 5; i++) {
+			if (fake.complete()) {
+				return;
+			}
+			waitABit(500);
+		}
+
+	}
+
+	private void waitABit(int millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+
+}


### PR DESCRIPTION
 - test and proper environment is constructed
 - bundle version is bumped to 0.6

Test is centrated only a single call of `Accessmanager.evaluateConditions`, employing both real `EquinoxPermissionObservatory` and `EquinoxAccessManager`.  We fake conditions and permission emitter, who leases short-TTL `FeaturePermission`s.  All touched services bound with emulated event bus, which, it turn, keeps an eye  on each event posting and handling under testing.  

At the end of the day we check that all leased permissions are tracked by the `EquinoxPermissionObservatory` properly and all are publicly expired.

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>