### PR TITLE
553582 MailImplTest leaves `test.file` projeсt working directory

### DIFF
--- a/tests/org.eclipse.passage.lic.mail.tests/src/org/eclipse/passage/lic/mail/tests/MailImplTest.java
+++ b/tests/org.eclipse.passage.lic.mail.tests/src/org/eclipse/passage/lic/mail/tests/MailImplTest.java
@@ -109,6 +109,7 @@ public class MailImplTest {
 		if (fileAttachmentPath != null) {
 			Files.delete(fileAttachmentPath);
 		}
+		Files.deleteIfExists(Paths.get(MAIL_FILE_OUT));
 	}
 
 }


### PR DESCRIPTION
the file is scheduled for removal at the end of a test

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>