### PR TITLE
553629	lic.base - avoid dependency from OSGi FrameworkUtil

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
@@ -7,8 +7,7 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.eclipse.passage.lic.api;bundle-version="0.0.0";visibility:=reexport,
- org.eclipse.osgi
+Require-Bundle: org.eclipse.passage.lic.api;bundle-version="0.0.0";visibility:=reexport
 Export-Package: org.eclipse.passage.lic.base,
  org.eclipse.passage.lic.base.access,
  org.eclipse.passage.lic.base.conditions,

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/LicensingResults.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/LicensingResults.java
@@ -26,8 +26,6 @@ import java.util.Map;
 
 import org.eclipse.passage.lic.api.LicensingEvents;
 import org.eclipse.passage.lic.api.LicensingResult;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 /**
  * 
@@ -172,9 +170,8 @@ public final class LicensingResults {
 	 * @see LicensingResult
 	 */
 	public static LicensingResult createWarning(String message, Class<?> source, Map<String, Object> attachments) {
-		Bundle bundle = FrameworkUtil.getBundle(source);
-		return new BaseLicensingResult(WARNING, message, BaseLicensingResult.CODE_NOMINAL, bundle.getSymbolicName(),
-				null, Collections.emptyList(), attachments);
+		return new BaseLicensingResult(WARNING, message, BaseLicensingResult.CODE_NOMINAL, source.getName(), null,
+				Collections.emptyList(), attachments);
 	}
 
 	/**

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/base/tests/LicensingResultsTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/base/tests/LicensingResultsTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.base.tests;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.passage.lic.api.LicensingResult;
+import org.eclipse.passage.lic.base.LicensingResults;
+import org.junit.Test;
+
+/**
+ * {@linkplain LicensingResults} is going to be completely reworked from a
+ * bundle of static function to a set of classes.
+ * 
+ */
+public class LicensingResultsTest {
+	@Test
+	public void testBlankOk() {
+		LicensingResult ok = createOk();
+		assertBlankOkIsCorrect(ok);
+		assertMessageIsBlank(ok);
+		assertSourceIsNotBlank(ok);
+	}
+
+	@Test
+	public void testInformativeOk() {
+		String message = "informative"; //$NON-NLS-1$
+		LicensingResult ok = createOk(message);
+		assertBlankOkIsCorrect(ok);
+		assertInformativeOkIsCorrect(ok, message);
+		assertSourceIsNotBlank(ok);
+	}
+
+	@Test
+	public void testSourcedOk() {
+		String message = "highly informative"; //$NON-NLS-1$
+		String source = "the blue"; //$NON-NLS-1$
+		LicensingResult ok = createOk(message, source);
+		assertBlankOkIsCorrect(ok);
+		assertInformativeOkIsCorrect(ok, message);
+		assertSourcedIsCorrect(ok, source);
+	}
+
+	private LicensingResult createOk() {
+		return LicensingResults.createOK();
+	}
+
+	private LicensingResult createOk(String message) {
+		return LicensingResults.createOK(message);
+	}
+
+	private LicensingResult createOk(String message, String source) {
+		return LicensingResults.createOK(message, source);
+	}
+
+	private void assertBlankOkIsCorrect(LicensingResult ok) {
+		assertNotNull("Creation failed", ok); //$NON-NLS-1$
+		assertTrue("Creation is incorrect: OK expected", ok.getSeverity() == LicensingResult.OK); //$NON-NLS-1$
+	}
+
+	private void assertInformativeOkIsCorrect(LicensingResult ok, String message) {
+		assertTrue("Creation is incorrect: unexpected message", message.equals(ok.getMessage())); //$NON-NLS-1$
+	}
+
+	private void assertSourcedIsCorrect(LicensingResult ok, String source) {
+		assertTrue("Creation is incorrect: unexpected source", source.equals(ok.getSource())); //$NON-NLS-1$
+	}
+
+	private void assertMessageIsBlank(LicensingResult result) {
+		assertTrue("Creation is incorrect: unexpected message", result.getMessage().length() == 0); //$NON-NLS-1$
+	}
+
+	private void assertSourceIsNotBlank(LicensingResult result) {
+		assertNotNull("Creation is incorrect: source is null", result.getSource()); //$NON-NLS-1$
+		assertTrue("Creation is incorrect: source is blank", result.getSource().length() != 0); //$NON-NLS-1$
+	}
+
+}


### PR DESCRIPTION
 - `Class.getName()` is used instead of a bundle symbolic name
 - OSGi dependency is eliminated from `lic.base`

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>