### PR TITLE
Bug 553644 - [Passage] switch to Orbit 2019-12

### DIFF
--- a/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
+++ b/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
@@ -51,7 +51,7 @@
 			<unit id="javax.mail" version="0.0.0"/>
 			<unit id="org.junit" version="0.0.0"/>
 			<unit id="org.mockito" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/S20191118194249/repository"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-12/"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
Switch to https://download.eclipse.org/tools/orbit/downloads/2019-12/

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>