### PR TITLE
Bug 558572 - [Passage] switch eclipse run repo to 4.15 stream

### DIFF
--- a/releng/org.eclipse.passage.parent/pom.xml
+++ b/releng/org.eclipse.passage.parent/pom.xml
@@ -42,7 +42,7 @@
 		<eclipse-repo.url>https://repo.eclipse.org/content/repositories/cbi/</eclipse-repo.url>
 		<cbi-snapshots-repo.url>https://repo.eclipse.org/content/repositories/cbi-snapshots/</cbi-snapshots-repo.url>
 
-		<eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.14-I-builds/</eclipserun-repo>
+		<eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.15-I-builds/</eclipserun-repo>
 		<released.baseline>https://download.eclipse.org/passage/updates/release/0.7.0/ldc/</released.baseline>
 		<staging.baseline>https://download.eclipse.org/passage/updates/release/0.7.0/ldc/</staging.baseline>
 


### PR DESCRIPTION
use https://download.eclipse.org/eclipse/updates/4.15-I-builds/

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>