### PR TITLE
Bug 558708 - passage.setup should install EMFForms tooling

### DIFF
--- a/releng/org.eclipse.passage.releng/passage.setup
+++ b/releng/org.eclipse.passage.releng/passage.setup
@@ -61,10 +61,14 @@
         name="org.eclipse.emf.sdk.feature.group"/>
     <requirement
         name="org.sonatype.tycho.m2e.feature.feature.group"/>
+    <requirement
+        name="org.eclipse.emf.ecp.sdk.feature.feature.group"/>
     <repository
         url="https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/LATEST/"/>
     <repository
         url="https://download.eclipse.org/modeling/emf/emf/builds/nightly/latest"/>
+    <repository
+        url="https://download.eclipse.org/releases/2019-12/"/>
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>
   </setupTask>
   <setupTask


### PR DESCRIPTION
Added "org.eclipse.emf.ecp.sdk.feature.feature.group" from
"https://download.eclipse.org/releases/2019-12/"

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>