### PR TITLE
Bug 558835 LIC Execute feature must have it's own branding plug-in

### DIFF
--- a/bundles/org.eclipse.passage.lic.execute.branding/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.execute.branding/META-INF/MANIFEST.MF
@@ -1,8 +1,9 @@
 Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.execute.branding
 Bundle-ManifestVersion: 2
-Bundle-SymbolicName: org.eclipse.passage.execute.branding
+Bundle-SymbolicName: org.eclipse.passage.lic.execute.branding
 Bundle-Version: 0.1.0.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/features/org.eclipse.passage.lic.execute.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.execute.feature/feature.xml
@@ -16,7 +16,7 @@
       label="%featureName"
       version="0.8.0.qualifier"
       provider-name="%providerName"
-      plugin="org.eclipse.passage.execute.branding"
+      plugin="org.eclipse.passage.lic.execute.branding"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
 
@@ -57,7 +57,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.passage.execute.branding"
+         id="org.eclipse.passage.lic.execute.branding"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
- invite new `org.eclipse.passage.lic.execute.branding` plug-in

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>