### PR TITLE
Bug 558954 LDC e3 template produce not compilable RCP project

### DIFF
--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE3Product/$pluginId$.product
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE3Product/$pluginId$.product
@@ -73,7 +73,7 @@
       <plugin id="org.eclipse.equinox.event"/>
       <plugin id="org.eclipse.equinox.preferences"/>
       <plugin id="org.eclipse.equinox.registry"/>
-      <plugin id="org.eclipse.equinox.util"/>
+      <plugin id="org.eclipse.help"/>
       <plugin id="org.eclipse.jface"/>
       <plugin id="org.eclipse.jface.databinding"/>
       <plugin id="org.eclipse.jface.text"/>
@@ -81,24 +81,23 @@
       <plugin id="org.eclipse.osgi.compatibility.state" fragment="true"/>
       <plugin id="org.eclipse.osgi.services"/>
       <plugin id="org.eclipse.osgi.util"/>
-      <plugin id="org.eclipse.text"/>
+      <plugin id="org.eclipse.passage.lic.api"/>
+      <plugin id="org.eclipse.passage.lic.base"/>
+      <plugin id="org.eclipse.passage.lic.e4.ui"/>
+      <plugin id="org.eclipse.passage.lic.equinox"/>
+      <plugin id="org.eclipse.passage.lic.jface"/>
       <plugin id="org.eclipse.swt"/>
       <plugin id="org.eclipse.swt.cocoa.macosx.x86_64" fragment="true"/>
       <plugin id="org.eclipse.swt.gtk.linux.ppc64" fragment="true"/>
       <plugin id="org.eclipse.swt.gtk.linux.x86_64" fragment="true"/>
       <plugin id="org.eclipse.swt.win32.win32.x86_64" fragment="true"/>
+      <plugin id="org.eclipse.text"/>
+      <plugin id="org.eclipse.ui"/>
+      <plugin id="org.eclipse.ui.workbench"/>
       <plugin id="org.w3c.css.sac"/>
       <plugin id="org.w3c.dom.events"/>
       <plugin id="org.w3c.dom.smil"/>
       <plugin id="org.w3c.dom.svg"/>
-      <plugin id="org.eclipse.passage.lic.api"/>
-      <plugin id="org.eclipse.passage.lic.base"/>
-      <plugin id="org.eclipse.passage.lic.equinox"/>
-      <plugin id="org.eclipse.passage.lic.jface"/>
-      <plugin id="org.eclipse.passage.lic.e4.ui"/>
-      <plugin id="org.eclipse.ui"/>
-      <plugin id="org.eclipse.help"/>
-      <plugin id="org.eclipse.ui.workbench"/>
    </plugins>
 
    <configurations>
@@ -109,6 +108,5 @@
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
       <plugin id="org.eclipse.passage.lic.equinox" autoStart="true" startLevel="4" />
    </configurations>
-
 
 </product>


### PR DESCRIPTION
 - org.eclipse.equinox.util reference is removed
 - formatting happened automatically on saving

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>