### PR TITLE
Bug 558954 LDC e3 template produce not compilable RCP project

### DIFF
--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/BaseLicensedTemplateSection.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/BaseLicensedTemplateSection.java
@@ -168,7 +168,6 @@ public abstract class BaseLicensedTemplateSection extends OptionTemplateSection 
 	protected List<String> getRCP3xDependencies() {
 		return Arrays.asList(//
 				"org.apache.felix.scr", //$NON-NLS-1$
-				"org.eclipse.equinox.util", //$NON-NLS-1$
 				"org.eclipse.equinox.event", //$NON-NLS-1$
 				"org.eclipse.core.runtime", //$NON-NLS-1$
 				"org.eclipse.ui", //$NON-NLS-1$


### PR DESCRIPTION
 - org.eclipse.equinox.util reference is removed

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>