### PR TITLE
Bug 559012 Provide branding image for Passage LIC Users feature

### DIFF
--- a/features/org.eclipse.passage.lic.users.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.users.feature/feature.xml
@@ -16,6 +16,7 @@
       label="%featureName"
       version="0.6.200.qualifier"
       provider-name="%providerName"
+      plugin="org.eclipse.passage.lic.users"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
 


### PR DESCRIPTION
make *LIC Users* feature reference `lic.users` plug-in as a branding one

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>