### PR TITLE
Bug 558833 - fix license header to use https and navigatable URL

### DIFF
--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.ldc.pde.ui.templates
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.ldc.pde.ui.templates;singleton:=true
-Bundle-Version: 0.5.100.qualifier
+Bundle-Version: 0.5.200.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.ldc.pde.ui.templates
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LDC PDE UI Templates
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2019, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/build.properties
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/plugin.xml
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/plugin.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
+<!--
+	Copyright (c) 2019, 2020 ArSysOp and others
+
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	https://www.eclipse.org/legal/epl-2.0/.
+
+	SPDX-License-Identifier: EPL-2.0
+
+	Contributors:
+		ArSysOp - initial API and implementation
+-->
 <plugin>
    <extension
          point="org.eclipse.pde.ui.pluginContent">

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/BaseLicensedTemplateSection.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/BaseLicensedTemplateSection.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/HelpContexts.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/HelpContexts.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE3ProductContentWizard.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE3ProductContentWizard.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE3ProductTemplateSection.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE3ProductTemplateSection.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE4ProductContentWizard.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE4ProductContentWizard.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE4ProductTemplateSection.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE4ProductTemplateSection.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/i18n/PdeUiTemplatesMessages.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/i18n/PdeUiTemplatesMessages.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/i18n/PdeUiTemplatesMessages.properties
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/i18n/PdeUiTemplatesMessages.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.ldc/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.ldc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.ldc
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.ldc;singleton:=true
-Bundle-Version: 0.5.200.qualifier
+Bundle-Version: 0.5.300.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/bundles/org.eclipse.passage.ldc/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.ldc/OSGI-INF/l10n/bundle.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LDC
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2019, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.ldc/about.ini
+++ b/bundles/org.eclipse.passage.ldc/about.ini
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.ldc/about.mappings
+++ b/bundles/org.eclipse.passage.ldc/about.mappings
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.ldc/about.properties
+++ b/bundles/org.eclipse.passage.ldc/about.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -20,5 +20,5 @@ blurb=Eclipse Passage Licensing Definition Components: PDE support\n\
 \n\
 Version: {featureVersion}\n\
 \n\
-(c) Copyright Eclipse contributors and others 2000, 2019.  All rights reserved.\n\
+(c) Copyright ArSysOp and others 2019, 2020.  All rights reserved.\n\
 Visit http://www.eclipse.org/passage

--- a/bundles/org.eclipse.passage.ldc/build.properties
+++ b/bundles/org.eclipse.passage.ldc/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.ldc/cheatsheets/rcp3x-composite.xml
+++ b/bundles/org.eclipse.passage.ldc/cheatsheets/rcp3x-composite.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2019 ArSysOp and others
+	Copyright (c) 2019, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/bundles/org.eclipse.passage.ldc/cheatsheets/rcp4x-composite.xml
+++ b/bundles/org.eclipse.passage.ldc/cheatsheets/rcp4x-composite.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2019 ArSysOp and others
+	Copyright (c) 2019, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/bundles/org.eclipse.passage.ldc/cheatsheets/tasks/rcp3x-create.xml
+++ b/bundles/org.eclipse.passage.ldc/cheatsheets/tasks/rcp3x-create.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-	Copyright (c) 2019 ArSysOp and others
+	Copyright (c) 2019, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/bundles/org.eclipse.passage.ldc/cheatsheets/tasks/rcp4x-create.xml
+++ b/bundles/org.eclipse.passage.ldc/cheatsheets/tasks/rcp4x-create.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-	Copyright (c) 2019 ArSysOp and others
+	Copyright (c) 2019, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/bundles/org.eclipse.passage.ldc/intro/css/overview.css
+++ b/bundles/org.eclipse.passage.ldc/intro/css/overview.css
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.ldc/intro/css/overview.properties
+++ b/bundles/org.eclipse.passage.ldc/intro/css/overview.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.ldc/intro/css/tutorials.css
+++ b/bundles/org.eclipse.passage.ldc/intro/css/tutorials.css
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.ldc/intro/css/tutorials.properties
+++ b/bundles/org.eclipse.passage.ldc/intro/css/tutorials.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.ldc/intro/overviewExtensionContent.xml
+++ b/bundles/org.eclipse.passage.ldc/intro/overviewExtensionContent.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
-	Copyright (c) 2019 ArSysOp and others
+	Copyright (c) 2019, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/bundles/org.eclipse.passage.ldc/intro/tutorialsExtensionContent.xml
+++ b/bundles/org.eclipse.passage.ldc/intro/tutorialsExtensionContent.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
-	Copyright (c) 2019 ArSysOp and others
+	Copyright (c) 2019, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/bundles/org.eclipse.passage.ldc/plugin.xml
+++ b/bundles/org.eclipse.passage.ldc/plugin.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <!--
-	Copyright (c) 2019 ArSysOp and others
+	Copyright (c) 2019, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 


### PR DESCRIPTION
Normalize header to recommended format: LDC

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>