### PR TITLE
Bug 558833 - fix license header to use https and navigatable URL

### DIFF
--- a/bundles/org.eclipse.passage.lic.users.e4.ui/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.users.e4.ui/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.users.e4.ui
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC Users E4 UI
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.users.e4.ui/build.properties
+++ b/bundles/org.eclipse.passage.lic.users.e4.ui/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.users.e4.ui/plugin.xml
+++ b/bundles/org.eclipse.passage.lic.users.e4.ui/plugin.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <!--
-	Copyright (c) 2018-2019 ArSysOp and others
+	Copyright (c) 2018, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/bundles/org.eclipse.passage.lic.users.e4.ui/src/org/eclipse/passage/lic/internal/users/e4/ui/UsersE4UiProcessor.java
+++ b/bundles/org.eclipse.passage.lic.users.e4.ui/src/org/eclipse/passage/lic/internal/users/e4/ui/UsersE4UiProcessor.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.ecore/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.users.ecore/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.users.ecore
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC Users Ecore
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.users.ecore/build.properties
+++ b/bundles/org.eclipse.passage.lic.users.ecore/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.users.edit/build.properties
+++ b/bundles/org.eclipse.passage.lic.users.edit/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.users.edit/plugin.properties
+++ b/bundles/org.eclipse.passage.lic.users.edit/plugin.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 pluginName = Passage LIC Users Edit Support
 providerName=Eclipse Passage
 
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.users.edit/plugin.xml
+++ b/bundles/org.eclipse.passage.lic.users.edit/plugin.xml
@@ -2,11 +2,11 @@
 <?eclipse version="3.0"?>
 
 <!--
-	Copyright (c) 2018-2019 ArSysOp and others
+	Copyright (c) 2018, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/bundles/org.eclipse.passage.lic.users.edit/src-gen/org/eclipse/passage/lic/users/edit/UsersEditPlugin.java
+++ b/bundles/org.eclipse.passage.lic.users.edit/src-gen/org/eclipse/passage/lic/users/edit/UsersEditPlugin.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.edit/src-gen/org/eclipse/passage/lic/users/edit/providers/UserItemProvider.java
+++ b/bundles/org.eclipse.passage.lic.users.edit/src-gen/org/eclipse/passage/lic/users/edit/providers/UserItemProvider.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.edit/src-gen/org/eclipse/passage/lic/users/edit/providers/UserLicenseItemProvider.java
+++ b/bundles/org.eclipse.passage.lic.users.edit/src-gen/org/eclipse/passage/lic/users/edit/providers/UserLicenseItemProvider.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.edit/src-gen/org/eclipse/passage/lic/users/edit/providers/UserOriginItemProvider.java
+++ b/bundles/org.eclipse.passage.lic.users.edit/src-gen/org/eclipse/passage/lic/users/edit/providers/UserOriginItemProvider.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.edit/src-gen/org/eclipse/passage/lic/users/edit/providers/UsersItemProviderAdapterFactory.java
+++ b/bundles/org.eclipse.passage.lic.users.edit/src-gen/org/eclipse/passage/lic/users/edit/providers/UsersItemProviderAdapterFactory.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.migration/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.users.migration/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.users.migration
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC Users Migration
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.users.migration/build.properties
+++ b/bundles/org.eclipse.passage.lic.users.migration/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.users.migration/src/org/eclipse/passage/lic/internal/users/migration/UsersMigrator.java
+++ b/bundles/org.eclipse.passage.lic.users.migration/src/org/eclipse/passage/lic/internal/users/migration/UsersMigrator.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.model/build.properties
+++ b/bundles/org.eclipse.passage.lic.users.model/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.users.model/plugin.properties
+++ b/bundles/org.eclipse.passage.lic.users.model/plugin.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.users.model
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 pluginName = Passage LIC Users Model
 providerName=Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.users.model/plugin.xml
+++ b/bundles/org.eclipse.passage.lic.users.model/plugin.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <!--
-	Copyright (c) 2018-2019 ArSysOp and others
+	Copyright (c) 2018, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/api/User.java
+++ b/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/api/User.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/api/UserLicense.java
+++ b/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/api/UserLicense.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/api/UserOrigin.java
+++ b/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/api/UserOrigin.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/impl/UserImpl.java
+++ b/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/impl/UserImpl.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/impl/UserLicenseImpl.java
+++ b/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/impl/UserLicenseImpl.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
@@ -13,8 +13,8 @@
 package org.eclipse.passage.lic.users.model.impl;
 
 import java.util.Date;
-
 import java.util.Objects;
+
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.ecore.EClass;

--- a/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/impl/UserOriginImpl.java
+++ b/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/impl/UserOriginImpl.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/impl/UsersFactoryImpl.java
+++ b/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/impl/UsersFactoryImpl.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/impl/UsersPackageImpl.java
+++ b/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/impl/UsersPackageImpl.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/meta/UsersFactory.java
+++ b/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/meta/UsersFactory.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/meta/UsersPackage.java
+++ b/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/meta/UsersPackage.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/util/UsersAdapterFactory.java
+++ b/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/util/UsersAdapterFactory.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/util/UsersSwitch.java
+++ b/bundles/org.eclipse.passage.lic.users.model/src-gen/org/eclipse/passage/lic/users/model/util/UsersSwitch.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.users/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.users
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC Users
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.users/about.ini
+++ b/bundles/org.eclipse.passage.lic.users/about.ini
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.users/about.mappings
+++ b/bundles/org.eclipse.passage.lic.users/about.mappings
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.users/about.properties
+++ b/bundles/org.eclipse.passage.lic.users/about.properties
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -20,5 +20,5 @@ blurb=Passage Licensing Integration Components: EMF Model API for Users data\n\
 \n\
 Version: {featureVersion}\n\
 \n\
-Copyright (c) 2018-2020 ArSysOp and others. All rights reserved.\n\
+Copyright (c) 2018, 2020 ArSysOp and others. All rights reserved.\n\
 Visit http://www.eclipse.org/passage

--- a/bundles/org.eclipse.passage.lic.users/build.properties
+++ b/bundles/org.eclipse.passage.lic.users/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2020 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.users/src/org/eclipse/passage/lic/users/UserDescriptor.java
+++ b/bundles/org.eclipse.passage.lic.users/src/org/eclipse/passage/lic/users/UserDescriptor.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users/src/org/eclipse/passage/lic/users/UserLicenseDescriptor.java
+++ b/bundles/org.eclipse.passage.lic.users/src/org/eclipse/passage/lic/users/UserLicenseDescriptor.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users/src/org/eclipse/passage/lic/users/UserOriginDescriptor.java
+++ b/bundles/org.eclipse.passage.lic.users/src/org/eclipse/passage/lic/users/UserOriginDescriptor.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users/src/org/eclipse/passage/lic/users/registry/UserRegistry.java
+++ b/bundles/org.eclipse.passage.lic.users/src/org/eclipse/passage/lic/users/registry/UserRegistry.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.users/src/org/eclipse/passage/lic/users/registry/UserRegistryEvents.java
+++ b/bundles/org.eclipse.passage.lic.users/src/org/eclipse/passage/lic/users/registry/UserRegistryEvents.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/features/org.eclipse.passage.lic.users.feature/build.properties
+++ b/features/org.eclipse.passage.lic.users.feature/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/features/org.eclipse.passage.lic.users.feature/feature.properties
+++ b/features/org.eclipse.passage.lic.users.feature/feature.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.users.feature
 ###############################################################################
-# Copyright (c) 2019-2020 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -15,7 +15,7 @@
 featureName=Passage LIC Users
 providerName=Eclipse Passage
 description=Passage Licensing Integration Components EMF Model API for Users data
-copyright=Copyright (c) 2018-2020 ArSysOp and others.\n\
+copyright=Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/features/org.eclipse.passage.lic.users.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.users.feature/feature.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2019-2020 ArSysOp and others
+	Copyright (c) 2019, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/tests/org.eclipse.passage.lic.users.migration.tests/OSGI-INF/l10n/bundle.properties
+++ b/tests/org.eclipse.passage.lic.users.migration.tests/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.users.migration.tests
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC Users Migration Tests
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/tests/org.eclipse.passage.lic.users.migration.tests/build.properties
+++ b/tests/org.eclipse.passage.lic.users.migration.tests/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/tests/org.eclipse.passage.lic.users.migration.tests/src/org/eclipse/passage/lic/users/migration/tests/UsersMigratorTest.java
+++ b/tests/org.eclipse.passage.lic.users.migration.tests/src/org/eclipse/passage/lic/users/migration/tests/UsersMigratorTest.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *


### PR DESCRIPTION
Normalize header to recommended format: LIC Users

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>