### PR TITLE
Bug 558833 - fix license header to use https and navigatable URL

### DIFF
--- a/bundles/org.eclipse.passage.lic.oshi/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.oshi/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.oshi	
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC OSHI
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.oshi/about.ini
+++ b/bundles/org.eclipse.passage.lic.oshi/about.ini
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.oshi/about.mappings
+++ b/bundles/org.eclipse.passage.lic.oshi/about.mappings
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.oshi/about.properties
+++ b/bundles/org.eclipse.passage.lic.oshi/about.properties
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -20,5 +20,5 @@ blurb=Passage Licensing Integration Components: OSHI integration\n\
 \n\
 Version: {featureVersion}\n\
 \n\
-Copyright (c) 2018-2020 ArSysOp and others. All rights reserved.\n\
+Copyright (c) 2018, 2020 ArSysOp and others. All rights reserved.\n\
 Visit http://www.eclipse.org/passage

--- a/bundles/org.eclipse.passage.lic.oshi/build.properties
+++ b/bundles/org.eclipse.passage.lic.oshi/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2020 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/OshiHardwareInspector.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/OshiHardwareInspector.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/OshiPermissionEmitter.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/OshiPermissionEmitter.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/i18n/OshiMessages.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/i18n/OshiMessages.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/i18n/OshiMessages.properties
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/i18n/OshiMessages.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/oshi/OshiHal.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/oshi/OshiHal.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/features/org.eclipse.passage.lic.oshi.feature/build.properties
+++ b/features/org.eclipse.passage.lic.oshi.feature/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/features/org.eclipse.passage.lic.oshi.feature/feature.properties
+++ b/features/org.eclipse.passage.lic.oshi.feature/feature.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.oshi.feature
 ###############################################################################
-# Copyright (c) 2018-2020 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -15,7 +15,7 @@
 featureName=Passage LIC OSHI
 providerName=Eclipse Passage
 description=Passage Licensing Integration Components: OSHI integration
-copyright=Copyright (c) 2018-2020 ArSysOp and others.\n\
+copyright=Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/features/org.eclipse.passage.lic.oshi.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.oshi.feature/feature.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2018-2020 ArSysOp and others
+	Copyright (c) 2018, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/tests/org.eclipse.passage.lic.oshi.tests/OSGI-INF/l10n/bundle.properties
+++ b/tests/org.eclipse.passage.lic.oshi.tests/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.oshi.tests
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC OSHI Tests
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/tests/org.eclipse.passage.lic.oshi.tests/build.properties
+++ b/tests/org.eclipse.passage.lic.oshi.tests/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/tests/org.eclipse.passage.lic.oshi.tests/src/org/eclipse/passage/lic/oshi/tests/OshiHalTest.java
+++ b/tests/org.eclipse.passage.lic.oshi.tests/src/org/eclipse/passage/lic/oshi/tests/OshiHalTest.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/tests/org.eclipse.passage.lic.oshi.tests/src/org/eclipse/passage/lic/oshi/tests/OshiHardwareInspectorTest.java
+++ b/tests/org.eclipse.passage.lic.oshi.tests/src/org/eclipse/passage/lic/oshi/tests/OshiHardwareInspectorTest.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/tests/org.eclipse.passage.lic.oshi.tests/src/org/eclipse/passage/lic/oshi/tests/OshiPermissionEmitterTest.java
+++ b/tests/org.eclipse.passage.lic.oshi.tests/src/org/eclipse/passage/lic/oshi/tests/OshiPermissionEmitterTest.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *


### PR DESCRIPTION
Normalize header to recommended format: LIC OSHI

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>