### PR TITLE
Bug 558833 - fix license header to use https and navigatable URL

### DIFF
--- a/bundles/org.eclipse.passage.lic.hc/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.hc/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.net
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC HC
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2019, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.hc/about.ini
+++ b/bundles/org.eclipse.passage.lic.hc/about.ini
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.hc/about.mappings
+++ b/bundles/org.eclipse.passage.lic.hc/about.mappings
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.hc/about.properties
+++ b/bundles/org.eclipse.passage.lic.hc/about.properties
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -20,5 +20,5 @@ blurb=Passage Licensing Integration Components: HTTP\n\
 \n\
 Version: {featureVersion}\n\
 \n\
-Copyright (c) 2018-2020 ArSysOp and others. All rights reserved.\n\
+Copyright (c) 2018, 2020 ArSysOp and others. All rights reserved.\n\
 Visit http://www.eclipse.org/passage

--- a/bundles/org.eclipse.passage.lic.hc/build.properties
+++ b/bundles/org.eclipse.passage.lic.hc/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019-2020 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/hc/HttpRequests.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/hc/HttpRequests.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/HcConditionMiner.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/HcConditionMiner.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/i18n/HcMessages.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/i18n/HcMessages.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/i18n/HcMessages.properties
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/i18n/HcMessages.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.net/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.net/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.net
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC Net
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.net/about.ini
+++ b/bundles/org.eclipse.passage.lic.net/about.ini
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.net/about.mappings
+++ b/bundles/org.eclipse.passage.lic.net/about.mappings
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.net/about.properties
+++ b/bundles/org.eclipse.passage.lic.net/about.properties
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -20,5 +20,5 @@ blurb=Passage Licensing Integration Components: Network facilities integration\n
 \n\
 Version: {featureVersion}\n\
 \n\
-Copyright (c) 2018-2020 ArSysOp and others. All rights reserved.\n\
+Copyright (c) 2018, 2020 ArSysOp and others. All rights reserved.\n\
 Visit http://www.eclipse.org/passage

--- a/bundles/org.eclipse.passage.lic.net/build.properties
+++ b/bundles/org.eclipse.passage.lic.net/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2020 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/NtpPermissionEmitter.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/NtpPermissionEmitter.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/net/LicensingNet.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/net/LicensingNet.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/net/TimeConditions.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/net/TimeConditions.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/features/org.eclipse.passage.lic.hc.feature/build.properties
+++ b/features/org.eclipse.passage.lic.hc.feature/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/features/org.eclipse.passage.lic.hc.feature/feature.properties
+++ b/features/org.eclipse.passage.lic.hc.feature/feature.properties
@@ -4,7 +4,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -15,7 +15,7 @@
 featureName=Passage LIC HC
 providerName=Eclipse Passage
 description=Passage Licensing Integration Components HTTP components integration
-copyright=Copyright (c) 2019-2020 ArSysOp and others.\n\
+copyright=Copyright (c) 2019, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/features/org.eclipse.passage.lic.hc.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.hc.feature/feature.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2019-2020 ArSysOp and others
+	Copyright (c) 2019, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/features/org.eclipse.passage.lic.net.feature/build.properties
+++ b/features/org.eclipse.passage.lic.net.feature/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/features/org.eclipse.passage.lic.net.feature/feature.properties
+++ b/features/org.eclipse.passage.lic.net.feature/feature.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.net.feature
 ###############################################################################
-# Copyright (c) 2018-2020 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -15,7 +15,7 @@
 featureName=Passage LIC Net
 providerName=Eclipse Passage
 description=Passage Licensing Integration Components Network facilities integration
-copyright=Copyright (c) 2018-2020 ArSysOp and others.\n\
+copyright=Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/features/org.eclipse.passage.lic.net.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.net.feature/feature.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2018-2020 ArSysOp and others
+	Copyright (c) 2018, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/tests/org.eclipse.passage.lic.net.tests/OSGI-INF/l10n/bundle.properties
+++ b/tests/org.eclipse.passage.lic.net.tests/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.net.tests
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC Net Tests
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/tests/org.eclipse.passage.lic.net.tests/build.properties
+++ b/tests/org.eclipse.passage.lic.net.tests/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/tests/org.eclipse.passage.lic.net.tests/src/org/eclipse/passage/lic/net/tests/NtpPermissionEmitterTest.java
+++ b/tests/org.eclipse.passage.lic.net.tests/src/org/eclipse/passage/lic/net/tests/NtpPermissionEmitterTest.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/tests/org.eclipse.passage.lic.net.tests/src/org/eclipse/passage/lic/net/tests/TimeConditionsTest.java
+++ b/tests/org.eclipse.passage.lic.net.tests/src/org/eclipse/passage/lic/net/tests/TimeConditionsTest.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *


### PR DESCRIPTION
Normalize header to recommended format: LIC Net and LIC HC

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>