### PR TITLE
Bug 558833 - fix license header to use https and navigatable URL

### DIFF
--- a/bundles/org.eclipse.passage.lic.email/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.email/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.email
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC Email
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2019, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.email/build.properties
+++ b/bundles/org.eclipse.passage.lic.email/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.email/src/org/eclipse/passage/lic/email/EmailDescriptor.java
+++ b/bundles/org.eclipse.passage.lic.email/src/org/eclipse/passage/lic/email/EmailDescriptor.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.email/src/org/eclipse/passage/lic/email/Mailing.java
+++ b/bundles/org.eclipse.passage.lic.email/src/org/eclipse/passage/lic/email/Mailing.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.mail/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.mail/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.mail
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others 
+# Copyright (c) 2019, 2020 ArSysOp and others 
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC Mail
 Bundle-Vendor = Eclipse Passage 
-Bundle-Copyright = Copyright (c) 2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2019, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.mail/build.properties
+++ b/bundles/org.eclipse.passage.lic.mail/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.mail/src/org/eclipse/passage/lic/internal/mail/EmailDescriptorImpl.java
+++ b/bundles/org.eclipse.passage.lic.mail/src/org/eclipse/passage/lic/internal/mail/EmailDescriptorImpl.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.mail/src/org/eclipse/passage/lic/internal/mail/MailImpl.java
+++ b/bundles/org.eclipse.passage.lic.mail/src/org/eclipse/passage/lic/internal/mail/MailImpl.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/features/org.eclipse.passage.lic.mail.feature/build.properties
+++ b/features/org.eclipse.passage.lic.mail.feature/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/features/org.eclipse.passage.lic.mail.feature/feature.properties
+++ b/features/org.eclipse.passage.lic.mail.feature/feature.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.mail.feature
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -15,7 +15,7 @@
 featureName=Passage LIC Mail
 providerName=Eclipse Passage
 description=Passage Licensing Integration Components for Mail Support 
-copyright=Copyright (c) 2018-2019 ArSysOp and others.\n\
+copyright=Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/features/org.eclipse.passage.lic.mail.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.mail.feature/feature.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2019 ArSysOp and others
+	Copyright (c) 2019, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/tests/org.eclipse.passage.lic.mail.tests/OSGI-INF/l10n/bundle.properties
+++ b/tests/org.eclipse.passage.lic.mail.tests/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.mail.tests
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC Mail Tests
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/tests/org.eclipse.passage.lic.mail.tests/build.properties
+++ b/tests/org.eclipse.passage.lic.mail.tests/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/tests/org.eclipse.passage.lic.mail.tests/src/org/eclipse/passage/lic/mail/tests/MailImplTest.java
+++ b/tests/org.eclipse.passage.lic.mail.tests/src/org/eclipse/passage/lic/mail/tests/MailImplTest.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *


### PR DESCRIPTION
Normalize header to recommended format: LIC Mail

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>