### PR TITLE
Bug 558833 - fix license header to use https and navigatable URL

### DIFF
--- a/bundles/org.eclipse.passage.lic.equinox/META-INF/p2.inf
+++ b/bundles/org.eclipse.passage.lic.equinox/META-INF/p2.inf
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.equinox/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.equinox/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.equinox
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC Equinox
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.equinox/about.ini
+++ b/bundles/org.eclipse.passage.lic.equinox/about.ini
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.equinox/about.mappings
+++ b/bundles/org.eclipse.passage.lic.equinox/about.mappings
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.equinox/about.properties
+++ b/bundles/org.eclipse.passage.lic.equinox/about.properties
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -20,5 +20,5 @@ blurb=Passage Licensing Integration Components: Equinox \n\
 \n\
 Version: {featureVersion}\n\
 \n\
-Copyright (c) 2018-2020 ArSysOp and others. All rights reserved.\n\
+Copyright (c) 2018, 2020 ArSysOp and others. All rights reserved.\n\
 Visit http://www.eclipse.org/passage

--- a/bundles/org.eclipse.passage.lic.equinox/build.properties
+++ b/bundles/org.eclipse.passage.lic.equinox/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2020 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/ApplicationConfigurations.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/ApplicationConfigurations.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/LicensingEquinox.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/LicensingEquinox.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/app/ApplicationBranding.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/app/ApplicationBranding.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/conditions/EquinoxConditions.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/conditions/EquinoxConditions.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/io/BundleKeyKeeper.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/io/BundleKeyKeeper.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/io/EquinoxPaths.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/io/EquinoxPaths.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/requirements/EquinoxRequirements.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/requirements/EquinoxRequirements.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/restrictions/EquinoxRestrictions.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/restrictions/EquinoxRestrictions.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/EquinoxEvents.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/EquinoxEvents.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/EquinoxLicensingReporter.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/EquinoxLicensingReporter.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/EquinoxAccessManager.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/EquinoxAccessManager.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/EquinoxPermissionEmitterRegistry.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/EquinoxPermissionEmitterRegistry.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/EquinoxPermissionObservatory.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/EquinoxPermissionObservatory.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/EquinoxRestrictionExecutorRegistry.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/EquinoxRestrictionExecutorRegistry.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/EquinoxConditionMinerRegistry.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/EquinoxConditionMinerRegistry.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/EquinoxConditionTransportRegistry.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/EquinoxConditionTransportRegistry.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/InstallLocationConditionMiner.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/InstallLocationConditionMiner.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/UserHomeConditionMiner.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/UserHomeConditionMiner.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/i18n/EquinoxMessages.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/i18n/EquinoxMessages.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp and others
+ * Copyright (c) 2019, 2020 ArSysOp and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/i18n/EquinoxMessages.properties
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/i18n/EquinoxMessages.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/inspector/EquinoxFeatureCase.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/inspector/EquinoxFeatureCase.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/inspector/EquinoxFeatureInspector.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/inspector/EquinoxFeatureInspector.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/io/EquinoxKeyKeeperRegistry.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/io/EquinoxKeyKeeperRegistry.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/io/EquinoxStreamCodecRegistry.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/io/EquinoxStreamCodecRegistry.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/BundleCapabilityResolver.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/BundleCapabilityResolver.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ComponentConfigurationResolver.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ComponentConfigurationResolver.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/restrictions/EquinoxPermissionExaminer.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/restrictions/EquinoxPermissionExaminer.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/features/org.eclipse.passage.lic.equinox.feature/build.properties
+++ b/features/org.eclipse.passage.lic.equinox.feature/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/features/org.eclipse.passage.lic.equinox.feature/feature.properties
+++ b/features/org.eclipse.passage.lic.equinox.feature/feature.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.equinox.feature
 ###############################################################################
-# Copyright (c) 2018-2020 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -15,7 +15,7 @@
 featureName=Passage LIC Equinox
 providerName=Eclipse Passage
 description=Passage Licensing Integration Components Equinox includes runtime interfaces and its implementation for Eclipse Equinox
-copyright=Copyright (c) 2018-2020 ArSysOp and others.\n\
+copyright=Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/features/org.eclipse.passage.lic.equinox.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.equinox.feature/feature.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2018-2020 ArSysOp and others
+	Copyright (c) 2018, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 

--- a/tests/org.eclipse.passage.lic.equinox.tests/OSGI-INF/l10n/bundle.properties
+++ b/tests/org.eclipse.passage.lic.equinox.tests/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.equinox.tests
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC Equinox Tests
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/tests/org.eclipse.passage.lic.equinox.tests/build.properties
+++ b/tests/org.eclipse.passage.lic.equinox.tests/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/tests/ComponentConfigurationResolverTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/tests/ComponentConfigurationResolverTest.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/tests/EquinoxAccessManagerTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/tests/EquinoxAccessManagerTest.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *


### PR DESCRIPTION
Normalize header to recommended format: LIC Equinox

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>