### PR TITLE
Bug 558833 - fix license header to use https and navigatable URL

### DIFF
--- a/bundles/org.eclipse.passage.loc.edit.ui/src/org/eclipse/passage/loc/internal/edit/ui/i18n/EditUiMessages.java
+++ b/bundles/org.eclipse.passage.loc.edit.ui/src/org/eclipse/passage/loc/internal/edit/ui/i18n/EditUiMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp and others
+ * Copyright (c) 2019, 2020 ArSysOp and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.edit.ui/src/org/eclipse/passage/loc/internal/edit/ui/i18n/EditUiMessages.properties
+++ b/bundles/org.eclipse.passage.loc.edit.ui/src/org/eclipse/passage/loc/internal/edit/ui/i18n/EditUiMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.features.core/src/org/eclipse/passage/loc/internal/features/core/i18n/FeaturesCoreMessages.java
+++ b/bundles/org.eclipse.passage.loc.features.core/src/org/eclipse/passage/loc/internal/features/core/i18n/FeaturesCoreMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp and others
+ * Copyright (c) 2019, 2020 ArSysOp and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.features.core/src/org/eclipse/passage/loc/internal/features/core/i18n/FeaturesCoreMessages.properties
+++ b/bundles/org.eclipse.passage.loc.features.core/src/org/eclipse/passage/loc/internal/features/core/i18n/FeaturesCoreMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.features.ui/src/org/eclipse/passage/loc/internal/features/ui/i18n/FeatureUiMessages.java
+++ b/bundles/org.eclipse.passage.loc.features.ui/src/org/eclipse/passage/loc/internal/features/ui/i18n/FeatureUiMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp and others
+ * Copyright (c) 2019, 2020 ArSysOp and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.features.ui/src/org/eclipse/passage/loc/internal/features/ui/i18n/FeatureUiMessages.properties
+++ b/bundles/org.eclipse.passage.loc.features.ui/src/org/eclipse/passage/loc/internal/features/ui/i18n/FeatureUiMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.licenses.core/src/org/eclipse/passage/loc/internal/licenses/core/LicenseMailSupport.java
+++ b/bundles/org.eclipse.passage.loc.licenses.core/src/org/eclipse/passage/loc/internal/licenses/core/LicenseMailSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.licenses.core/src/org/eclipse/passage/loc/internal/licenses/core/i18n/LicensesCoreMessages.java
+++ b/bundles/org.eclipse.passage.loc.licenses.core/src/org/eclipse/passage/loc/internal/licenses/core/i18n/LicensesCoreMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp and others
+ * Copyright (c) 2019, 2020 ArSysOp and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.licenses.core/src/org/eclipse/passage/loc/internal/licenses/core/i18n/LicensesCoreMessages.properties
+++ b/bundles/org.eclipse.passage.loc.licenses.core/src/org/eclipse/passage/loc/internal/licenses/core/i18n/LicensesCoreMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.licenses.core/src/org/eclipse/passage/loc/licenses/core/Licenses.java
+++ b/bundles/org.eclipse.passage.loc.licenses.core/src/org/eclipse/passage/loc/licenses/core/Licenses.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.licenses.ui/src/org/eclipse/passage/loc/internal/licenses/ui/i18n/LicensesUiMessages.java
+++ b/bundles/org.eclipse.passage.loc.licenses.ui/src/org/eclipse/passage/loc/internal/licenses/ui/i18n/LicensesUiMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp and others
+ * Copyright (c) 2019, 2020 ArSysOp and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.operator/about.mappings
+++ b/bundles/org.eclipse.passage.loc.operator/about.mappings
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/i18n/ProductsCoreMessages.java
+++ b/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/i18n/ProductsCoreMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/i18n/ProductsCoreMessages.properties
+++ b/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/i18n/ProductsCoreMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.products.emfforms/src/org/eclipse/passage/loc/products/emfforms/renderers/PrivateKeyRenderer.java
+++ b/bundles/org.eclipse.passage.loc.products.emfforms/src/org/eclipse/passage/loc/products/emfforms/renderers/PrivateKeyRenderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.products.emfforms/src/org/eclipse/passage/loc/products/emfforms/renderers/PrivateKeyRendererService.java
+++ b/bundles/org.eclipse.passage.loc.products.emfforms/src/org/eclipse/passage/loc/products/emfforms/renderers/PrivateKeyRendererService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.products.emfforms/src/org/eclipse/passage/loc/products/emfforms/renderers/ProductVersionKeyRenderer.java
+++ b/bundles/org.eclipse.passage.loc.products.emfforms/src/org/eclipse/passage/loc/products/emfforms/renderers/ProductVersionKeyRenderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.products.emfforms/src/org/eclipse/passage/loc/products/emfforms/renderers/PublicKeyRenderer.java
+++ b/bundles/org.eclipse.passage.loc.products.emfforms/src/org/eclipse/passage/loc/products/emfforms/renderers/PublicKeyRenderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.products.emfforms/src/org/eclipse/passage/loc/products/emfforms/renderers/PublicKeyRendererService.java
+++ b/bundles/org.eclipse.passage.loc.products.emfforms/src/org/eclipse/passage/loc/products/emfforms/renderers/PublicKeyRendererService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.products.ui/src/org/eclipse/passage/loc/internal/products/ui/i18n/ProductsUiMessages.java
+++ b/bundles/org.eclipse.passage.loc.products.ui/src/org/eclipse/passage/loc/internal/products/ui/i18n/ProductsUiMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.products.ui/src/org/eclipse/passage/loc/internal/products/ui/i18n/ProductsUiMessages.properties
+++ b/bundles/org.eclipse.passage.loc.products.ui/src/org/eclipse/passage/loc/internal/products/ui/i18n/ProductsUiMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.core/.classpath
+++ b/bundles/org.eclipse.passage.loc.report.core/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2019 ArSysOp and others
+ Copyright (c) 2019, 2020 ArSysOp and others
  This program and the accompanying materials are made available under the
  terms of the Eclipse Public License 2.0 which is available at
  https://www.eclipse.org/legal/epl-2.0/.

--- a/bundles/org.eclipse.passage.loc.report.core/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.loc.report.core/OSGI-INF/l10n/bundle.properties
@@ -1,6 +1,6 @@
 #Properties file for org.eclipse.passage.loc.report.core
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,7 @@
 ###############################################################################
 Bundle-Name = Passage LOC Report Core
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2019, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.loc.report.core/build.properties
+++ b/bundles/org.eclipse.passage.loc.report.core/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/Csv.java
+++ b/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/Csv.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/CsvExportService.java
+++ b/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/CsvExportService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/CustomerStorage.java
+++ b/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/CustomerStorage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/Customers.java
+++ b/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/Customers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/CustomersFetch.java
+++ b/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/CustomersFetch.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/CustomersForProductsQuery.java
+++ b/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/CustomersForProductsQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/ExistingFileStream.java
+++ b/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/ExistingFileStream.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/ExportService.java
+++ b/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/ExportService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/Messages.java
+++ b/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/ProductCustomer.java
+++ b/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/ProductCustomer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/ProductCustomersToCsv.java
+++ b/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/ProductCustomersToCsv.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/ProductNames.java
+++ b/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/ProductNames.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/messages.properties
+++ b/bundles/org.eclipse.passage.loc.report.core/src/org/eclipse/passage/loc/report/internal/core/messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.users.core/src/org/eclipse/passage/loc/internal/users/core/i18n/UsersCoreMessages.java
+++ b/bundles/org.eclipse.passage.loc.users.core/src/org/eclipse/passage/loc/internal/users/core/i18n/UsersCoreMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.users.core/src/org/eclipse/passage/loc/internal/users/core/i18n/UsersCoreMessages.properties
+++ b/bundles/org.eclipse.passage.loc.users.core/src/org/eclipse/passage/loc/internal/users/core/i18n/UsersCoreMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.users.emfforms/src/org/eclipse/passage/loc/users/emfforms/renderers/ConditionExpressionRendererService.java
+++ b/bundles/org.eclipse.passage.loc.users.emfforms/src/org/eclipse/passage/loc/users/emfforms/renderers/ConditionExpressionRendererService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.users.emfforms/src/org/eclipse/passage/loc/users/emfforms/renderers/ConditionTypeRendererService.java
+++ b/bundles/org.eclipse.passage.loc.users.emfforms/src/org/eclipse/passage/loc/users/emfforms/renderers/ConditionTypeRendererService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.users.emfforms/src/org/eclipse/passage/loc/users/emfforms/renderers/PackIdentifierRenderer.java
+++ b/bundles/org.eclipse.passage.loc.users.emfforms/src/org/eclipse/passage/loc/users/emfforms/renderers/PackIdentifierRenderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.users.emfforms/src/org/eclipse/passage/loc/users/emfforms/renderers/PackIdentifierRendererService.java
+++ b/bundles/org.eclipse.passage.loc.users.emfforms/src/org/eclipse/passage/loc/users/emfforms/renderers/PackIdentifierRendererService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.users.ui/src/org/eclipse/passage/loc/internal/users/ui/i18n/UsersUiMessages.java
+++ b/bundles/org.eclipse.passage.loc.users.ui/src/org/eclipse/passage/loc/internal/users/ui/i18n/UsersUiMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.users.ui/src/org/eclipse/passage/loc/internal/users/ui/i18n/UsersUiMessages.properties
+++ b/bundles/org.eclipse.passage.loc.users.ui/src/org/eclipse/passage/loc/internal/users/ui/i18n/UsersUiMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.workbench.emfforms/src/org/eclipse/passage/loc/internal/workbench/emfforms/OperatorDialogWrapper.java
+++ b/bundles/org.eclipse.passage.loc.workbench.emfforms/src/org/eclipse/passage/loc/internal/workbench/emfforms/OperatorDialogWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.workbench.emfforms/src/org/eclipse/passage/loc/internal/workbench/emfforms/i18n/WorkbenchEmfformsMessages.java
+++ b/bundles/org.eclipse.passage.loc.workbench.emfforms/src/org/eclipse/passage/loc/internal/workbench/emfforms/i18n/WorkbenchEmfformsMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.workbench.emfforms/src/org/eclipse/passage/loc/internal/workbench/emfforms/i18n/WorkbenchEmfformsMessages.properties
+++ b/bundles/org.eclipse.passage.loc.workbench.emfforms/src/org/eclipse/passage/loc/internal/workbench/emfforms/i18n/WorkbenchEmfformsMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.workbench.emfforms/src/org/eclipse/passage/loc/workbench/emfforms/renderers/FileContentRenderer.java
+++ b/bundles/org.eclipse.passage.loc.workbench.emfforms/src/org/eclipse/passage/loc/workbench/emfforms/renderers/FileContentRenderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.workbench/src/org/eclipse/passage/loc/internal/workbench/i18n/WorkbenchMessages.java
+++ b/bundles/org.eclipse.passage.loc.workbench/src/org/eclipse/passage/loc/internal/workbench/i18n/WorkbenchMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.workbench/src/org/eclipse/passage/loc/internal/workbench/i18n/WorkbenchMessages.properties
+++ b/bundles/org.eclipse.passage.loc.workbench/src/org/eclipse/passage/loc/internal/workbench/i18n/WorkbenchMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.workbench/src/org/eclipse/passage/loc/jface/dialogs/DateDialog.java
+++ b/bundles/org.eclipse.passage.loc.workbench/src/org/eclipse/passage/loc/jface/dialogs/DateDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.yars.api/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.loc.yars.api/OSGI-INF/l10n/bundle.properties
@@ -1,6 +1,6 @@
 #Properties file for org.eclipse.passage.loc.yars.api
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LOC YARS API
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2019, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.loc.yars.api/build.properties
+++ b/bundles/org.eclipse.passage.loc.yars.api/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/DOSHandleMedia.java
+++ b/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/DOSHandleMedia.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/DefaultDOSHandler.java
+++ b/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/DefaultDOSHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/Export.java
+++ b/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/Export.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/ExportData.java
+++ b/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/ExportData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/FetchParams.java
+++ b/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/FetchParams.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/FetchedData.java
+++ b/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/FetchedData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/ListMedia.java
+++ b/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/ListMedia.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/Query.java
+++ b/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/Query.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/ReportException.java
+++ b/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/ReportException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/Storage.java
+++ b/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/Storage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/Unsafe.java
+++ b/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/Unsafe.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/package-info.java
+++ b/bundles/org.eclipse.passage.loc.yars.api/src/org/eclipse/passage/loc/yars/internal/api/package-info.java
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.api.tests/OSGI-INF/l10n/bundle.properties
+++ b/tests/org.eclipse.passage.loc.api.tests/OSGI-INF/l10n/bundle.properties
@@ -1,6 +1,6 @@
 #Properties file for org.eclipse.passage.loc.api.tests
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.api.tests/build.properties
+++ b/tests/org.eclipse.passage.loc.api.tests/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.api.tests/src/org/eclipse/passage/loc/api/tests/ZeroOneManyTest.java
+++ b/tests/org.eclipse.passage.loc.api.tests/src/org/eclipse/passage/loc/api/tests/ZeroOneManyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.report.core.tests/OSGI-INF/l10n/bundle.properties
+++ b/tests/org.eclipse.passage.loc.report.core.tests/OSGI-INF/l10n/bundle.properties
@@ -1,6 +1,6 @@
 #Properties file for org.eclipse.passage.loc.report.core.tests
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LOC Report Core Tests
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2019, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/tests/org.eclipse.passage.loc.report.core.tests/build.properties
+++ b/tests/org.eclipse.passage.loc.report.core.tests/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.report.core.tests/src/org/eclipse/passage/loc/report/internal/core/ExportCustomersCommandTest.java
+++ b/tests/org.eclipse.passage.loc.report.core.tests/src/org/eclipse/passage/loc/report/internal/core/ExportCustomersCommandTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.report.core.tests/src/org/eclipse/passage/loc/report/internal/core/FakeCustomersBase.java
+++ b/tests/org.eclipse.passage.loc.report.core.tests/src/org/eclipse/passage/loc/report/internal/core/FakeCustomersBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.report.core.tests/src/org/eclipse/passage/loc/report/internal/core/FakeUserDescriptor.java
+++ b/tests/org.eclipse.passage.loc.report.core.tests/src/org/eclipse/passage/loc/report/internal/core/FakeUserDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.yars.api.tests/OSGI-INF/l10n/bundle.properties
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/OSGI-INF/l10n/bundle.properties
@@ -1,6 +1,6 @@
 #Properties file for org.eclipse.passage.loc.yars.api.tests
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LOC YARS API Tests
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2019, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/tests/org.eclipse.passage.loc.yars.api.tests/build.properties
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/export/All.java
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/export/All.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/export/Csv.java
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/export/Csv.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/export/Enlistment.java
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/export/Enlistment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/export/ExportTest.java
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/export/ExportTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/export/ExportedEntry.java
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/export/ExportedEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/export/Fetch.java
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/export/Fetch.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/export/Json.java
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/export/Json.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/model/InMemoryStorage.java
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/model/InMemoryStorage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/model/StoredEntry.java
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/model/StoredEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/pagination/Fetch.java
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/pagination/Fetch.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/pagination/Page.java
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/pagination/Page.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/pagination/PaginationSettings.java
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/pagination/PaginationSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/pagination/PaginationTest.java
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/src/org/eclipse/passage/loc/yars/internal/api/pagination/PaginationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at


### PR DESCRIPTION
Normalize header to recommended format: LOC Others

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>