### PR TITLE
Bug 558833 - fix license header to use https and navigatable URL

### DIFF
--- a/bundles/org.eclipse.passage.lic.emf/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.emf/OSGI-INF/l10n/bundle.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.emf
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC EMF
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018-2019 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.emf/about.ini
+++ b/bundles/org.eclipse.passage.lic.emf/about.ini
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.emf/about.mappings
+++ b/bundles/org.eclipse.passage.lic.emf/about.mappings
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.emf/about.properties
+++ b/bundles/org.eclipse.passage.lic.emf/about.properties
@@ -3,7 +3,7 @@
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -20,5 +20,5 @@ blurb=Passage Licensing Integration Components: EMF API for Licensing metadata\n
 \n\
 Version: {featureVersion}\n\
 \n\
-Copyright (c) 2018-2020 ArSysOp and others. All rights reserved.\n\
+Copyright (c) 2018, 2020 ArSysOp and others. All rights reserved.\n\
 Visit http://www.eclipse.org/passage

--- a/bundles/org.eclipse.passage.lic.emf/build.properties
+++ b/bundles/org.eclipse.passage.lic.emf/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2020 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/ecore/DomainContentAdapter.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/ecore/DomainContentAdapter.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/ecore/EditingDomainRegistry.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/ecore/EditingDomainRegistry.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/ecore/LicensingEcore.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/ecore/LicensingEcore.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/ecore/ResourceSetPersistence.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/ecore/ResourceSetPersistence.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/ecore/ResourceSetProvider.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/ecore/ResourceSetProvider.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/ecore/util/DelegatingEFactory.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/ecore/util/DelegatingEFactory.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/ecore/util/DelegatingEPackage.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/ecore/util/DelegatingEPackage.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/edit/BaseDomainRegistry.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/edit/BaseDomainRegistry.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/edit/ClassifierInitializer.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/edit/ClassifierInitializer.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/edit/ComposedAdapterFactoryProvider.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/edit/ComposedAdapterFactoryProvider.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/edit/EditingDomainRegistryAccess.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/edit/EditingDomainRegistryAccess.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/edit/LabeledDiagnostician.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/edit/LabeledDiagnostician.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/edit/SelectionCommandAdvisor.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/edit/SelectionCommandAdvisor.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 ArSysOp
+ * Copyright (c) 2018, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/internal/emf/i18n/EmfMessages.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/internal/emf/i18n/EmfMessages.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2019 ArSysOp
+ * Copyright (c) 2019, 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0/.
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/internal/emf/i18n/EmfMessages.properties
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/internal/emf/i18n/EmfMessages.properties
@@ -1,11 +1,11 @@
 BaseDomainRegistry_ok_load=Loaded {0}
 BaseDomainRegistry_ok_unload=Unloaded {0}
 ###############################################################################
-# Copyright (c) 2019 ArSysOp and others
+# Copyright (c) 2019, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/features/org.eclipse.passage.lic.emf.feature/build.properties
+++ b/features/org.eclipse.passage.lic.emf.feature/build.properties
@@ -1,9 +1,9 @@
 ###############################################################################
-# Copyright (c) 2018-2019 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #

--- a/features/org.eclipse.passage.lic.emf.feature/feature.properties
+++ b/features/org.eclipse.passage.lic.emf.feature/feature.properties
@@ -1,10 +1,10 @@
 #Properties file for org.eclipse.passage.lic.emf.feature
 ###############################################################################
-# Copyright (c) 2018-2020 ArSysOp and others
+# Copyright (c) 2018, 2020 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0.
+# https://www.eclipse.org/legal/epl-2.0/.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -15,7 +15,7 @@
 featureName=Passage LIC EMF
 providerName=Eclipse Passage
 description=Passage Licensing Integration Components EMF API for Licensing metadata
-copyright=Copyright (c) 2018-2020 ArSysOp and others.\n\
+copyright=Copyright (c) 2018, 2020 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/features/org.eclipse.passage.lic.emf.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.emf.feature/feature.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2018-2020 ArSysOp and others
+	Copyright (c) 2018, 2020 ArSysOp and others
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
-	http://www.eclipse.org/legal/epl-2.0.
+	https://www.eclipse.org/legal/epl-2.0/.
 
 	SPDX-License-Identifier: EPL-2.0
 


### PR DESCRIPTION
Normalize header to recommended format: LIC EMF

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>