### PR TITLE
Bug 558955 - [Passage] Application without product throws NPE on startup

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/access/BaseAccessManager.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/access/BaseAccessManager.java
@@ -139,7 +139,7 @@ public class BaseAccessManager implements AccessManager {
 	public Iterable<LicensingRequirement> resolveRequirements(LicensingConfiguration configuration) {
 		List<LicensingRequirement> result = new ArrayList<>();
 		String source = getClass().getName();
-		if (configuration == null) {
+		if (configuration == null || LicensingConfigurations.INVALID.equals(configuration)) {
 			String featureId = LicensingConfigurations.IDENTIFIER_INVALID;
 			result.add(LicensingRequirements.createConfigurationError(featureId, source));
 		} else {

--- a/bundles/org.eclipse.passage.lic.e4.ui/src/org/eclipse/passage/lic/internal/e4/ui/restrictions/WorkbenchRestrictionExecutor.java
+++ b/bundles/org.eclipse.passage.lic.e4.ui/src/org/eclipse/passage/lic/internal/e4/ui/restrictions/WorkbenchRestrictionExecutor.java
@@ -21,6 +21,7 @@ import org.eclipse.passage.lic.api.restrictions.RestrictionExecutor;
 import org.eclipse.passage.lic.api.restrictions.RestrictionVerdict;
 import org.eclipse.passage.lic.base.LicensingResults;
 import org.eclipse.passage.lic.base.restrictions.RestrictionVerdicts;
+import org.eclipse.passage.lic.equinox.ApplicationConfigurations;
 import org.eclipse.passage.lic.jface.dialogs.LicensingStatusDialog;
 import org.eclipse.swt.widgets.Shell;
 import org.osgi.framework.BundleContext;
@@ -50,7 +51,7 @@ public class WorkbenchRestrictionExecutor implements RestrictionExecutor {
 
 	@Override
 	public LicensingResult execute(Iterable<RestrictionVerdict> verdicts) {
-		String featureId = applicationContext.getBrandingId();
+		String featureId = ApplicationConfigurations.getLicensingProductIdentifier(applicationContext);
 		RestrictionVerdict lastVerdict = RestrictionVerdicts.resolveLastVerdict(verdicts, featureId);
 		boolean showDialog = RestrictionVerdicts.shouldPauseExecution(lastVerdict);
 		IEclipseContext serviceContext = EclipseContextFactory.getServiceContext(bundleContext);

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/ApplicationConfigurations.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/ApplicationConfigurations.java
@@ -94,7 +94,16 @@ public class ApplicationConfigurations {
 		if (property != null) {
 			return property;
 		}
-		return application.getBrandingId();
+		String brandingId = application.getBrandingId();
+		if (brandingId != null) {
+			return brandingId;
+		}
+		String applicationId = application.getBrandingApplication();
+		if (applicationId != null) {
+			return applicationId;
+		}
+		// OK, no more ideas
+		return LicensingConfigurations.INVALID.getProductIdentifier();
 	}
 
 	public static String getLicensingContacts() {

--- a/tests/org.eclipse.passage.lic.equinox.tests/.settings/.api_filters
+++ b/tests/org.eclipse.passage.lic.equinox.tests/.settings/.api_filters
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.passage.lic.equinox.tests" version="2">
+    <resource path="src/org/eclipse/passage/lic/equinox/tests/ApplicationConfigurationsTest.java" type="org.eclipse.passage.lic.equinox.tests.ApplicationConfigurationsTest$InvalidApplicationContext">
+        <filter comment="Bug 558955 - [Passage] new RCP based on LDC e3 licensed application template throws NPE on startup" id="574619656">
+            <message_arguments>
+                <message_argument value="IApplicationContext"/>
+                <message_argument value="InvalidApplicationContext"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/tests/ApplicationConfigurationsTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/tests/ApplicationConfigurationsTest.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.equinox.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+
+import org.eclipse.equinox.app.IApplication;
+import org.eclipse.equinox.app.IApplicationContext;
+import org.eclipse.passage.lic.base.LicensingConfigurations;
+import org.eclipse.passage.lic.equinox.ApplicationConfigurations;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+
+public class ApplicationConfigurationsTest {
+
+	private final class InvalidApplicationContext implements IApplicationContext {
+		@Override
+		public void setResult(Object result, IApplication application) {
+		}
+
+		@Override
+		public String getBrandingProperty(String key) {
+			return null;
+		}
+
+		@Override
+		public String getBrandingName() {
+			return null;
+		}
+
+		@Override
+		public String getBrandingId() {
+			return null;
+		}
+
+		@Override
+		public String getBrandingDescription() {
+			return null;
+		}
+
+		@Override
+		public Bundle getBrandingBundle() {
+			return null;
+		}
+
+		@Override
+		public String getBrandingApplication() {
+			return null;
+		}
+
+		@SuppressWarnings("rawtypes")
+		@Override
+		public Map getArguments() {
+			return null;
+		}
+
+		@Override
+		public void applicationRunning() {
+		}
+	}
+
+	@Test
+	public void testInvalidProduct() {
+		assertEquals(LicensingConfigurations.INVALID.getProductIdentifier(),
+				ApplicationConfigurations.getLicensingProductIdentifier(null));
+		assertEquals(LicensingConfigurations.INVALID.getProductIdentifier(),
+				ApplicationConfigurations.getLicensingProductIdentifier(new InvalidApplicationContext()));
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/ConfigurationRequirementIntegrationTest.java
+++ b/tests/org.eclipse.passage.lic.integration.tests/src/org/eclipse/passage/lic/integration/tests/ConfigurationRequirementIntegrationTest.java
@@ -12,7 +12,8 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.integration.tests;
 
-import static org.eclipse.passage.lic.base.LicensingProperties.*;
+import static org.eclipse.passage.lic.base.LicensingProperties.LICENSING_RESTRICTION_LEVEL_DEFAULT;
+import static org.eclipse.passage.lic.base.LicensingProperties.LICENSING_RESTRICTION_LEVEL_ERROR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -27,8 +28,19 @@ import org.junit.Test;
 public class ConfigurationRequirementIntegrationTest extends LicIntegrationBase {
 
 	@Test
-	public void testResolveRequirementsPositive() {
+	public void testResolveRequirementsInvalid() {
 		Iterable<LicensingRequirement> resolved = accessManager.resolveRequirements(LicensingConfigurations.INVALID);
+		Map<String, LicensingRequirement> requirements = new HashMap<>();
+		for (LicensingRequirement cr : resolved) {
+			requirements.put(cr.getFeatureIdentifier(), cr);
+		}
+		assertEquals(1, requirements.size());
+	}
+
+	@Test
+	public void testResolveRequirementsPositive() {
+		Iterable<LicensingRequirement> resolved = accessManager
+				.resolveRequirements(LicensingConfigurations.create(SOME_DECRYPTED_PRODUCT, SOME_PRODUCT_VERSION));
 		Map<String, LicensingRequirement> requirements = new HashMap<>();
 		for (LicensingRequirement cr : resolved) {
 			requirements.put(cr.getFeatureIdentifier(), cr);


### PR DESCRIPTION
Wrap IApplicationContext with safe productId resolution.
Always generate licensing requirement for invalid configuration.

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>